### PR TITLE
Fix boot-qemu build order

### DIFF
--- a/boot-qemu/Makefile
+++ b/boot-qemu/Makefile
@@ -2,24 +2,26 @@ NASM     = nasm
 ASMFLAGS = -f bin
 NODE     = node
 
-KERNEL_BIN = ../kernel/bin/exos.bin
-DISK_IMG   = ./bin/disk.img
-BOOT_BIN   = ./bin/boot.bin
+KERNEL_BIN  = ../kernel/bin/exos.bin
+DISK_IMG    = ./bin/disk.img
+BOOT_BIN    = ./bin/boot.bin
+SECTOR_INFO = kernel_sectors.inc
 
 all: $(DISK_IMG)
 
-# Étape 1 : Générer le SuperBlock + boot-info.txt
-$(SECTOR_INFO): $(KERNEL_BIN) superblock.js
-	$(NODE) superblock.js > $(SECTOR_INFO)
+# Step 1: generate kernel sector info
+$(SECTOR_INFO): $(KERNEL_BIN) calc_kernel_sectors.js
+	$(NODE) calc_kernel_sectors.js
 
-# Étape 2 : Assembler le bootloader avec la bonne info secteur
+# Step 2: assemble the bootloader with sector info
 $(BOOT_BIN): boot-qemu.asm $(SECTOR_INFO)
 	$(NASM) $(ASMFLAGS) -o $(BOOT_BIN) boot-qemu.asm
 
-# Étape 3 : Construire l’image disque
-$(DISK_IMG): $(BOOT_BIN)
+# Step 3: build the disk image and superblock
+$(DISK_IMG): $(BOOT_BIN) superblock.js
 	cp $(BOOT_BIN) $(DISK_IMG)
 	dd if=/dev/zero bs=512 count=100 >> $(DISK_IMG) 2>/dev/null
+	$(NODE) superblock.js
 
 clean:
-	rm -f $(DISK_IMG) $(BOOT_BIN) $(SECTOR_INFO)
+rm -f $(DISK_IMG) $(BOOT_BIN) $(SECTOR_INFO)

--- a/boot-qemu/calc_kernel_sectors.js
+++ b/boot-qemu/calc_kernel_sectors.js
@@ -1,0 +1,18 @@
+// boot-qemu/calc_kernel_sectors.js
+const fs = require('fs');
+const path = require('path');
+
+const kernelPath = path.join(__dirname, '../kernel/bin/exos.bin');
+const outputPath = path.join(__dirname, 'kernel_sectors.inc');
+
+if (!fs.existsSync(kernelPath)) {
+    console.error(`ERROR: Kernel not found at ${kernelPath}`);
+    process.exit(1);
+}
+
+const size = fs.statSync(kernelPath).size;
+const sectors = Math.ceil(size / 512);
+
+fs.writeFileSync(outputPath, `NUM_SECTORS equ ${sectors}\n`);
+console.log(`Kernel size: ${sectors} sectors`);
+

--- a/boot-qemu/superblock.js
+++ b/boot-qemu/superblock.js
@@ -43,6 +43,3 @@ fs.closeSync(fd);
 console.log(`✔ SuperBlock written at LBA ${superblockLBA}`);
 console.log(`  Kernel: ${kernelSectors} sectors at LBA ${kernelLBA}`);
 console.log(`  Entry : ${entrySegment.toString(16)}:${entryOffset.toString(16).padStart(4, '0')}`);
-
-// Create a file with number of kernel sectors
-fs.writeFileSync("kernel_sectors.inc", `NUM_SECTORS equ ${kernelSectors}\n`);


### PR DESCRIPTION
## Summary
- resolve circular dependency for boot-qemu image
- write kernel size in a new `calc_kernel_sectors.js`
- simplify `superblock.js`
- update Makefile build steps

## Testing
- `make` *(fails: `i686-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d65343a483308e7a51abe92fb36e