### PR TITLE
Fix disk image build

### DIFF
--- a/boot-qemu/Makefile
+++ b/boot-qemu/Makefile
@@ -18,9 +18,8 @@ $(BOOT_BIN): boot-qemu.asm $(SECTOR_INFO)
 	$(NASM) $(ASMFLAGS) -o $(BOOT_BIN) boot-qemu.asm
 
 # Step 3: build the disk image and superblock
-$(DISK_IMG): $(BOOT_BIN) superblock.js
+$(DISK_IMG): $(BOOT_BIN) superblock.js $(KERNEL_BIN)
 	cp $(BOOT_BIN) $(DISK_IMG)
-	dd if=/dev/zero bs=512 count=100 >> $(DISK_IMG) 2>/dev/null
 	$(NODE) superblock.js
 
 clean:


### PR DESCRIPTION
## Summary
- include kernel when building the disk image
- write the kernel into the disk image via `superblock.js`

## Testing
- `make clean`
- `make` *(fails: `i686-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6889eb5c945083308c0d48e0ef740d6a