### PR TITLE
Use designated struct initializers

### DIFF
--- a/kernel/source/Kernel.c
+++ b/kernel/source/Kernel.c
@@ -35,7 +35,9 @@ STR Text_OSTitle[] =
 /***************************************************************************/
 
 PHYSICAL StubAddress = 1;
-KERNELSTARTUPINFO KernelStartup = {1};
+KERNELSTARTUPINFO KernelStartup = {
+    .Loader_SS = 1,
+};
 
 LPGATEDESCRIPTOR IDT = (LPGATEDESCRIPTOR)LA_IDT;
 LPSEGMENTDESCRIPTOR GDT = (LPSEGMENTDESCRIPTOR)LA_GDT;
@@ -45,55 +47,103 @@ LPPAGEBITMAP PPB = (LPPAGEBITMAP)LA_PPB;
 
 /***************************************************************************/
 
-static LIST DesktopList = {NULL,           NULL,          NULL, 0,
-                           KernelMemAlloc, KernelMemFree, NULL};
+static LIST DesktopList = {
+    .First = NULL,
+    .Last = NULL,
+    .Current = NULL,
+    .NumItems = 0,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
 /***************************************************************************/
 
-static LIST ProcessList = {(LPLISTNODE)&KernelProcess,
-                           (LPLISTNODE)&KernelProcess,
-                           (LPLISTNODE)&KernelProcess,
-                           1,
-                           KernelMemAlloc,
-                           KernelMemFree,
-                           NULL};
+static LIST ProcessList = {
+    .First = (LPLISTNODE)&KernelProcess,
+    .Last = (LPLISTNODE)&KernelProcess,
+    .Current = (LPLISTNODE)&KernelProcess,
+    .NumItems = 1,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
 /***************************************************************************/
 
-static LIST TaskList = {(LPLISTNODE)&KernelTask,
-                        (LPLISTNODE)&KernelTask,
-                        (LPLISTNODE)&KernelTask,
-                        1,
-                        KernelMemAlloc,
-                        KernelMemFree,
-                        NULL};
+static LIST TaskList = {
+    .First = (LPLISTNODE)&KernelTask,
+    .Last = (LPLISTNODE)&KernelTask,
+    .Current = (LPLISTNODE)&KernelTask,
+    .NumItems = 1,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
 /***************************************************************************/
 
-static LIST MutexList = {(LPLISTNODE)&KernelMutex,
-                         (LPLISTNODE)&ConsoleMutex,
-                         (LPLISTNODE)&KernelMutex,
-                         9,
-                         KernelMemAlloc,
-                         KernelMemFree,
-                         NULL};
+static LIST MutexList = {
+    .First = (LPLISTNODE)&KernelMutex,
+    .Last = (LPLISTNODE)&ConsoleMutex,
+    .Current = (LPLISTNODE)&KernelMutex,
+    .NumItems = 9,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
 /***************************************************************************/
 
-static LIST DiskList = {NULL,           NULL,          NULL, 0,
-                        KernelMemAlloc, KernelMemFree, NULL};
+static LIST DiskList = {
+    .First = NULL,
+    .Last = NULL,
+    .Current = NULL,
+    .NumItems = 0,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
-static LIST FileSystemList = {NULL,           NULL,          NULL, 0,
-                              KernelMemAlloc, KernelMemFree, NULL};
+static LIST FileSystemList = {
+    .First = NULL,
+    .Last = NULL,
+    .Current = NULL,
+    .NumItems = 0,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
-static LIST FileList = {NULL,           NULL,          NULL, 0,
-                        KernelMemAlloc, KernelMemFree, NULL};
+static LIST FileList = {
+    .First = NULL,
+    .Last = NULL,
+    .Current = NULL,
+    .NumItems = 0,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
 /***************************************************************************/
 
-KERNELDATA Kernel = {&DesktopList, &ProcessList,       &TaskList,
-                     &MutexList,   &DiskList,          &FileSystemList,
-                     &FileList,    {"", 0, 0, 0, 0, 0}};
+KERNELDATA Kernel = {
+    .Desktop = &DesktopList,
+    .Process = &ProcessList,
+    .Task = &TaskList,
+    .Mutex = &MutexList,
+    .Disk = &DiskList,
+    .FileSystem = &FileSystemList,
+    .File = &FileList,
+    .CPU = {
+        .Name = "",
+        .Type = 0,
+        .Family = 0,
+        .Model = 0,
+        .Stepping = 0,
+        .Features = 0
+    }
+};
 
 /***************************************************************************/
 

--- a/kernel/source/SerMouse.c
+++ b/kernel/source/SerMouse.c
@@ -22,17 +22,19 @@
 
 U32 SerialMouseCommands(U32, U32);
 
-DRIVER SerialMouseDriver = {ID_DRIVER,
-                            1,
-                            NULL,
-                            NULL,
-                            DRIVER_TYPE_MOUSE,
-                            VER_MAJOR,
-                            VER_MINOR,
-                            "Jango73",
-                            "Not applicable",
-                            "Standard Serial Mouse",
-                            SerialMouseCommands};
+DRIVER SerialMouseDriver = {
+    .ID = ID_DRIVER,
+    .References = 1,
+    .Next = NULL,
+    .Prev = NULL,
+    .Type = DRIVER_TYPE_MOUSE,
+    .VersionMajor = VER_MAJOR,
+    .VersionMinor = VER_MINOR,
+    .Designer = "Jango73",
+    .Manufacturer = "Not applicable",
+    .Product = "Standard Serial Mouse",
+    .Command = SerialMouseCommands
+};
 
 /***************************************************************************/
 
@@ -46,7 +48,15 @@ typedef struct tag_MOUSEDATA {
     I32 PosY;
 } MOUSEDATA, *LPMOUSEDATA;
 
-static MOUSEDATA Mouse = {0};
+static MOUSEDATA Mouse = {
+    .Mutex = EMPTY_MUTEX,
+    .Busy = 0,
+    .DeltaX = 0,
+    .DeltaY = 0,
+    .Buttons = 0,
+    .PosX = 0,
+    .PosY = 0
+};
 
 /***************************************************************************/
 

--- a/kernel/source/SystemFS.c
+++ b/kernel/source/SystemFS.c
@@ -18,17 +18,19 @@
 
 U32 SystemFSCommands(U32, U32);
 
-DRIVER SystemFSDriver = {ID_DRIVER,
-                         1,
-                         NULL,
-                         NULL,
-                         DRIVER_TYPE_FILESYSTEM,
-                         VER_MAJOR,
-                         VER_MINOR,
-                         "Jango73",
-                         "EXOS",
-                         "Virtual Computer File System",
-                         SystemFSCommands};
+DRIVER SystemFSDriver = {
+    .ID = ID_DRIVER,
+    .References = 1,
+    .Next = NULL,
+    .Prev = NULL,
+    .Type = DRIVER_TYPE_FILESYSTEM,
+    .VersionMajor = VER_MAJOR,
+    .VersionMinor = VER_MINOR,
+    .Designer = "Jango73",
+    .Manufacturer = "EXOS",
+    .Product = "Virtual Computer File System",
+    .Command = SystemFSCommands
+};
 
 /***************************************************************************/
 
@@ -66,21 +68,20 @@ static LPSYSFSFILESYSTEM NewSystemFSFileSystem() {
     This = (LPSYSFSFILESYSTEM)KernelMemAlloc(sizeof(SYSFSFILESYSTEM));
     if (This == NULL) return NULL;
 
-    MemorySet(This, 0, sizeof(SYSFSFILESYSTEM));
-
-    This->Header.ID = ID_FILESYSTEM;
-    This->Header.References = 1;
-    This->Header.Next = NULL;
-    This->Header.Prev = NULL;
-    This->Header.Driver = &SystemFSDriver;
-    This->Root = NewSystemFileRoot();
+    *This = (SYSFSFILESYSTEM){
+        .Header = {
+            .ID = ID_FILESYSTEM,
+            .References = 1,
+            .Next = NULL,
+            .Prev = NULL,
+            .Mutex = EMPTY_MUTEX,
+            .Driver = &SystemFSDriver,
+            .Name = "System"
+        },
+        .Root = NewSystemFileRoot()
+    };
 
     InitMutex(&(This->Header.Mutex));
-
-    //-------------------------------------
-    // Assign a default name to the file system
-
-    StringCopy(This->Header.Name, TEXT("System"));
 
     return This;
 }

--- a/kernel/source/Task.c
+++ b/kernel/source/Task.c
@@ -15,30 +15,39 @@
 
 /***************************************************************************/
 
-LIST KernelTaskMessageList = {NULL,           NULL,          NULL, 0,
-                              KernelMemAlloc, KernelMemFree, NULL};
+LIST KernelTaskMessageList = {
+    .First = NULL,
+    .Last = NULL,
+    .Current = NULL,
+    .NumItems = 0,
+    .MemAllocFunc = KernelMemAlloc,
+    .MemFreeFunc = KernelMemFree,
+    .Destructor = NULL
+};
 
-TASK KernelTask = {ID_TASK,
-                   1,
-                   NULL,
-                   NULL,
-                   EMPTY_MUTEX,
-                   &KernelProcess,
-                   TASK_STATUS_RUNNING,
-                   TASK_PRIORITY_LOWER,
-                   NULL,
-                   NULL,
-                   0,
-                   0,
-                   SELECTOR_TSS_0,
-                   (LINEAR) LA_KERNEL_STACK + N_4KB,
-                   STK_SIZE - N_4KB,
-                   (LINEAR) LA_KERNEL_STACK,
-                   N_4KB,
-                   0,
-                   0,
-                   EMPTY_MUTEX,
-                   &KernelTaskMessageList};
+TASK KernelTask = {
+    .ID = ID_TASK,
+    .References = 1,
+    .Next = NULL,
+    .Prev = NULL,
+    .Mutex = EMPTY_MUTEX,
+    .Process = &KernelProcess,
+    .Status = TASK_STATUS_RUNNING,
+    .Priority = TASK_PRIORITY_LOWER,
+    .Function = NULL,
+    .Parameter = NULL,
+    .ReturnValue = 0,
+    .Table = 0,
+    .Selector = SELECTOR_TSS_0,
+    .StackBase = (LINEAR)LA_KERNEL_STACK + N_4KB,
+    .StackSize = STK_SIZE - N_4KB,
+    .SysStackBase = (LINEAR)LA_KERNEL_STACK,
+    .SysStackSize = N_4KB,
+    .Time = 0,
+    .WakeUpTime = 0,
+    .MessageMutex = EMPTY_MUTEX,
+    .Message = &KernelTaskMessageList
+};
 
 /***************************************************************************/
 
@@ -49,10 +58,10 @@ static LPMESSAGE NewMessage() {
 
     if (This == NULL) return NULL;
 
-    MemorySet(This, 0, sizeof(MESSAGE));
-
-    This->ID = ID_MESSAGE;
-    This->References = 1;
+    *This = (MESSAGE){
+        .ID = ID_MESSAGE,
+        .References = 1
+    };
 
     return This;
 }
@@ -85,25 +94,12 @@ LPTASK NewTask() {
         return NULL;
     }
 
-    MemorySet(This, 0, sizeof(TASK));
-
-    This->ID = ID_TASK;
-    This->References = 1;
-    This->Next = NULL;
-    This->Prev = NULL;
-    This->Process = NULL;
-    This->Status = 0;
-    This->Priority = 0;
-    This->Function = NULL;
-    This->Parameter = 0;
-    This->ReturnValue = 0;
-    This->Selector = 0;
-    This->StackBase = NULL;
-    This->StackSize = 0;
-    This->SysStackBase = NULL;
-    This->SysStackSize = 0;
-    This->Time = 0;
-    This->WakeUpTime = 0;
+    *This = (TASK){
+        .ID = ID_TASK,
+        .References = 1,
+        .Mutex = EMPTY_MUTEX,
+        .MessageMutex = EMPTY_MUTEX
+    };
 
     InitMutex(&(This->Mutex));
     InitMutex(&(This->MessageMutex));

--- a/kernel/source/VESA.c
+++ b/kernel/source/VESA.c
@@ -28,17 +28,19 @@
 
 U32 VESACommands(U32, U32);
 
-DRIVER VESADriver = {ID_DRIVER,
-                     1,
-                     NULL,
-                     NULL,
-                     DRIVER_TYPE_GRAPHICS,
-                     VER_MAJOR,
-                     VER_MINOR,
-                     "Jango73",
-                     "Video Electronics Standard Association",
-                     "VESA Compatible Graphics Card",
-                     VESACommands};
+DRIVER VESADriver = {
+    .ID = ID_DRIVER,
+    .References = 1,
+    .Next = NULL,
+    .Prev = NULL,
+    .Type = DRIVER_TYPE_GRAPHICS,
+    .VersionMajor = VER_MAJOR,
+    .VersionMinor = VER_MINOR,
+    .Designer = "Jango73",
+    .Manufacturer = "Video Electronics Standard Association",
+    .Product = "VESA Compatible Graphics Card",
+    .Command = VESACommands
+};
 
 /***************************************************************************/
 
@@ -166,7 +168,14 @@ VIDEOMODESPECS VESAModeSpecs[] = {
         c->CurrentBank = b;              \
     }
 
-VESACONTEXT VESAContext = {1};
+VESACONTEXT VESAContext = {
+    .Header = {
+        .ID = ID_GRAPHICSCONTEXT,
+        .References = 1,
+        .Mutex = EMPTY_MUTEX,
+        .Driver = &VESADriver
+    }
+};
 
 /***************************************************************************/
 
@@ -176,23 +185,23 @@ static U32 VESAInitialize() {
     //-------------------------------------
     // Initialize the context
 
-    MemorySet(&VESAContext, 0, sizeof(VESACONTEXT));
-
-    InitMutex(&(VESAContext.Header.Mutex));
-
-    VESAContext.Header.ID = ID_GRAPHICSCONTEXT;
-    VESAContext.Header.References = 1;
-    VESAContext.Header.Driver = &VESADriver;
-    VESAContext.Header.LoClip.X = 0;
-    VESAContext.Header.LoClip.Y = 0;
-    VESAContext.Header.HiClip.X = 100;
-    VESAContext.Header.HiClip.Y = 100;
-    VESAContext.Header.RasterOperation = ROP_SET;
-
-    VESAContext.ModeSpecs.SetPixel = SetPixel8;
-    VESAContext.ModeSpecs.GetPixel = GetPixel8;
-    VESAContext.ModeSpecs.Line = Line8;
-    VESAContext.ModeSpecs.Rect = Rect8;
+    VESAContext = (VESACONTEXT){
+        .Header = {
+            .ID = ID_GRAPHICSCONTEXT,
+            .References = 1,
+            .Mutex = EMPTY_MUTEX,
+            .Driver = &VESADriver,
+            .LoClip = { .X = 0, .Y = 0 },
+            .HiClip = { .X = 100, .Y = 100 },
+            .RasterOperation = ROP_SET
+        },
+        .ModeSpecs = {
+            .SetPixel = SetPixel8,
+            .GetPixel = GetPixel8,
+            .Line = Line8,
+            .Rect = Rect8
+        }
+    };
 
     //-------------------------------------
     // Get VESA general information


### PR DESCRIPTION
## Summary
- Clarified kernel bookkeeping structures by switching list and CPU data definitions to designated initializers for explicit field mapping.
- Replaced positional driver setups with declarative struct assignments and consolidated VESA context configuration.
- Simplified task/message creation with compound literals and initialized kernel task metadata using structured initializers.

## Testing
- `./2-format-all-code.sh` (failed: fdfind not found)
- `apt-get update` (failed: repository not signed)
- `make` (failed: i686-elf-gcc missing)


------
https://chatgpt.com/codex/tasks/task_e_6890fe76350c833093cfccec8de754e3