### PR TITLE
Simplify little-endian reads in magic checker

### DIFF
--- a/kernel/check-exos-magic.sh
+++ b/kernel/check-exos-magic.sh
@@ -21,9 +21,7 @@ fi
 
 # Little-endian uint32 at offset
 read_u32le() {
-	dd if="$1" bs=1 skip="$2" count=4 2>/dev/null | od -An -v -t x1 | tr -d ' \n' | \
-		awk '{print "0x" toupper($0)}' | \
-		xargs printf "%u\n"
+    od -An -t u4 --endian=little -N 4 -j "$2" "$1" | tr -d ' '
 }
 
 MAGIC=1163415379 # 0x534F5845


### PR DESCRIPTION
## Summary
- simplify 32-bit little-endian reads using `od`
- ensure checksum value reflects file contents

## Testing
- `./kernel/check-exos-magic.sh /tmp/test.bin`


------
https://chatgpt.com/codex/tasks/task_e_6898e30c6e48833090b4ed3a093f6436