### PR TITLE
Align data and bss sections

### DIFF
--- a/kernel/linker-bin.ld
+++ b/kernel/linker-bin.ld
@@ -18,11 +18,13 @@ SECTIONS
     }
 
     /* Data — aligned after .text */
+    . = ALIGN(0x1000);
     .data : AT(ALIGN(LOADADDR(.text) + SIZEOF(.text), 0x1000)) {
         *(.data)
     }
 
     /* BSS */
+    . = ALIGN(0x1000);
     .bss : AT(ALIGN(LOADADDR(.data) + SIZEOF(.data), 0x1000)) {
         __bss_init_start = .;
         *(global)

--- a/kernel/linker-elf.ld
+++ b/kernel/linker-elf.ld
@@ -17,11 +17,13 @@ SECTIONS
     }
 
     /* Data — aligned after .text */
+    . = ALIGN(0x1000);
     .data : AT(ALIGN(LOADADDR(.text) + SIZEOF(.text), 0x1000)) {
         *(.data)
     }
 
     /* BSS */
+    . = ALIGN(0x1000);
     .bss : AT(ALIGN(LOADADDR(.data) + SIZEOF(.data), 0x1000)) {
         __bss_init_start = .;
         *(global)


### PR DESCRIPTION
## Summary
- align data and bss VMAs in linker scripts

## Testing
- `make -C kernel` *(fails: i686-elf-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689901a356408330bd744321d73be315