### PR TITLE
Use designated initializers in RAM disk driver

### DIFF
--- a/kernel/source/RAMDisk.c
+++ b/kernel/source/RAMDisk.c
@@ -21,17 +21,19 @@
 
 U32 RAMDiskCommands(U32, U32);
 
-DRIVER RAMDiskDriver = {ID_DRIVER,
-                        1,
-                        NULL,
-                        NULL,
-                        DRIVER_TYPE_RAMDISK,
-                        VER_MAJOR,
-                        VER_MINOR,
-                        "Jango73",
-                        "IBM PC and compatibles",
-                        "RAM Disk Controller",
-                        RAMDiskCommands};
+DRIVER RAMDiskDriver = {
+    .ID = ID_DRIVER,
+    .References = 1,
+    .Next = NULL,
+    .Prev = NULL,
+    .Type = DRIVER_TYPE_RAMDISK,
+    .VersionMajor = VER_MAJOR,
+    .VersionMinor = VER_MINOR,
+    .Designer = "Jango73",
+    .Manufacturer = "IBM PC and compatibles",
+    .Product = "RAM Disk Controller",
+    .Command = RAMDiskCommands
+};
 
 /***************************************************************************/
 // RAM physical disk, derives from PHYSICALDISK


### PR DESCRIPTION
## Summary
- refactor RAMDisk driver definition to use designated initializers

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68999f2c5458833097e3e623264b8262