### PR TITLE
refactor: adapt to ABI header

### DIFF
--- a/kernel/include/User.h
+++ b/kernel/include/User.h
@@ -146,7 +146,7 @@ typedef U32 (*WINDOWFUNC)(HANDLE, U32, U32, U32);
 typedef BOOL (*ENUMVOLUMESFUNC)(HANDLE, LPVOID);
 
 typedef struct tag_SYSTEMINFO {
-    U32 Size;
+    ABI_HEADER Header;
     U32 TotalPhysicalMemory;
     U32 PhysicalMemoryUsed;
     U32 PhysicalMemoryAvail;

--- a/kernel/source/SYSCall.c
+++ b/kernel/source/SYSCall.c
@@ -38,9 +38,9 @@ U32 SysCall_GetSystemInfo(U32 Parameter) {
     LPSYSTEMINFO Info = (LPSYSTEMINFO)Parameter;
 
     if (Info) {
-        Info->Hdr.Size = sizeof(SYSTEMINFO);
-        Info->Hdr.Version = EXOS_ABI_VERSION;
-        Info->Hdr.Flags = 0;
+        Info->Header.Size = sizeof(SYSTEMINFO);
+        Info->Header.Version = EXOS_ABI_VERSION;
+        Info->Header.Flags = 0;
         Info->TotalPhysicalMemory = Memory;
         Info->PhysicalMemoryUsed = GetPhysicalMemoryUsed();
         Info->PhysicalMemoryAvail = Memory - Info->PhysicalMemoryUsed;
@@ -256,7 +256,7 @@ U32 SysCall_VirtualAlloc(U32 Parameter) {
     LPVIRTUALINFO Info = (LPVIRTUALINFO)Parameter;
 
     if (Info) {
-        return VirtualAlloc(Info->Base, Info->Size, Info->Flags);
+        return VirtualAlloc(Info->Base, Info->SizeBytes, Info->Flags);
     }
 
     return 0;
@@ -268,7 +268,7 @@ U32 SysCall_VirtualFree(U32 Parameter) {
     LPVIRTUALINFO Info = (LPVIRTUALINFO)Parameter;
 
     if (Info) {
-        return VirtualFree(Info->Base, Info->Size);
+        return VirtualFree(Info->Base, Info->SizeBytes);
     }
 
     return 0;

--- a/kernel/source/Shell.c
+++ b/kernel/source/Shell.c
@@ -516,7 +516,6 @@ static void CMD_run(LPSHELLCONTEXT Context) {
             ProcessInfo.Header.Size = sizeof(PROCESSINFO);
             ProcessInfo.Header.Version = EXOS_ABI_VERSION;
             ProcessInfo.Header.Flags = 0;
-            ProcessInfo.Flags = 0;
             ProcessInfo.FileName = FileName;
             ProcessInfo.CommandLine = NULL;
             ProcessInfo.StdOut = NULL;


### PR DESCRIPTION
## Summary
- replace SYSTEMINFO size field with ABI_HEADER
- update system calls for new header fields and size member names
- drop obsolete PROCESSINFO flag assignment

## Testing
- `make` *(fails: ld section .text LMA [00001000,0001cee7] overlaps section .eh_frame LMA [00000c88,00004ef3])*

------
https://chatgpt.com/codex/tasks/task_e_689af0c7052883309d5b317f787af717