### PR TITLE
Initialize GDT before loading

### DIFF
--- a/kernel/include/Kernel.h
+++ b/kernel/include/Kernel.h
@@ -169,6 +169,7 @@ void InitializeKernel(void);
 // Functions in Segment.c
 
 void InitSegmentDescriptor(LPSEGMENTDESCRIPTOR, U32);
+void InitGlobalDescriptorTable(LPSEGMENTDESCRIPTOR);
 void SetSegmentDescriptorBase(LPSEGMENTDESCRIPTOR, U32);
 void SetSegmentDescriptorLimit(LPSEGMENTDESCRIPTOR, U32);
 void SetTSSDescriptorBase(LPTSSDESCRIPTOR, U32);

--- a/kernel/source/Memory.c
+++ b/kernel/source/Memory.c
@@ -1052,9 +1052,10 @@ void InitializeMemoryManager(void) {
         DO_THE_SLEEPING_BEAUTY;
     }
 
-    // Allocate GDT storage in kernel VA (committed, RW) and load it.
+    // Allocate, initialize and load the GDT
     Kernel_i386.GDT = (LPSEGMENTDESCRIPTOR) AllocRegion(0, 0, GDT_SIZE, ALLOC_PAGES_COMMIT | ALLOC_PAGES_READWRITE);
 
+    InitGlobalDescriptorTable(Kernel_i386.GDT);
     LoadGlobalDescriptorTable((PHYSICAL)(Kernel_i386.GDT), GDT_SIZE - 1);
 
     // Log GDT contents

--- a/kernel/source/Segment.c
+++ b/kernel/source/Segment.c
@@ -11,6 +11,7 @@
 
 #include "../include/Base.h"
 #include "../include/I386.h"
+#include "../include/Kernel.h"
 #include "../include/String.h"
 
 /***************************************************************************/
@@ -33,6 +34,36 @@ void InitSegmentDescriptor(LPSEGMENTDESCRIPTOR This, U32 Type) {
     This->OperandSize = 1;
     This->Granularity = GDT_GRANULAR_4KB;
     This->Base_24_31 = 0x00;
+}
+
+/***************************************************************************/
+
+void InitGlobalDescriptorTable(LPSEGMENTDESCRIPTOR Table) {
+    MemorySet(Table, 0, GDT_SIZE);
+
+    InitSegmentDescriptor(&Table[2], GDT_TYPE_CODE);
+    Table[2].Privilege = GDT_PRIVILEGE_KERNEL;
+
+    InitSegmentDescriptor(&Table[3], GDT_TYPE_DATA);
+    Table[3].Privilege = GDT_PRIVILEGE_KERNEL;
+
+    InitSegmentDescriptor(&Table[4], GDT_TYPE_CODE);
+    Table[4].Privilege = GDT_PRIVILEGE_USER;
+
+    InitSegmentDescriptor(&Table[5], GDT_TYPE_DATA);
+    Table[5].Privilege = GDT_PRIVILEGE_USER;
+
+    InitSegmentDescriptor(&Table[6], GDT_TYPE_CODE);
+    Table[6].Privilege = GDT_PRIVILEGE_KERNEL;
+    Table[6].OperandSize = GDT_OPERANDSIZE_16;
+    Table[6].Granularity = GDT_GRANULAR_1B;
+    SetSegmentDescriptorLimit(&Table[6], N_1MB_M1);
+
+    InitSegmentDescriptor(&Table[7], GDT_TYPE_DATA);
+    Table[7].Privilege = GDT_PRIVILEGE_KERNEL;
+    Table[7].OperandSize = GDT_OPERANDSIZE_16;
+    Table[7].Granularity = GDT_GRANULAR_1B;
+    SetSegmentDescriptorLimit(&Table[7], N_1MB_M1);
 }
 
 /***************************************************************************/


### PR DESCRIPTION
## Summary
- add InitGlobalDescriptorTable to setup base descriptors
- load GDT after proper initialization in memory manager

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5003820c83308107637332837bcb