### PR TITLE
Map GDT to fixed linear region

### DIFF
--- a/kernel/source/Memory.c
+++ b/kernel/source/Memory.c
@@ -1052,14 +1052,30 @@ void InitializeMemoryManager(void) {
         DO_THE_SLEEPING_BEAUTY;
     }
 
-    // Allocate, initialize and load the GDT
-    Kernel_i386.GDT = (LPSEGMENTDESCRIPTOR) AllocPhysicalPage();
+    // Allocate a permanent linear region for the GDT
+    Kernel_i386.GDT = (LPSEGMENTDESCRIPTOR) AllocRegion(
+        0, 0, GDT_SIZE, ALLOC_PAGES_RESERVE | ALLOC_PAGES_READWRITE);
+    if (Kernel_i386.GDT == NULL) {
+        KernelLogText(LOG_ERROR, TEXT("[InitializeMemoryManager] AllocRegion for GDT failed"));
+        DO_THE_SLEEPING_BEAUTY;
+    }
+
+    U32 GdtPages = (GDT_SIZE + (PAGE_SIZE - 1)) >> PAGE_SIZE_MUL;
+    for (U32 Page = 0; Page < GdtPages; Page++) {
+        PHYSICAL Physical = AllocPhysicalPage();
+        if (Physical == NULL) {
+            KernelLogText(LOG_ERROR, TEXT("[InitializeMemoryManager] AllocPhysicalPage failed for GDT"));
+            DO_THE_SLEEPING_BEAUTY;
+        }
+        MapOnePage((LINEAR)Kernel_i386.GDT + (Page << PAGE_SIZE_MUL), Physical,
+                   /*RW*/1, PAGE_PRIVILEGE_KERNEL, /*WT*/0, /*UC*/0, /*Global*/0, /*Fixed*/1);
+    }
 
     InitGlobalDescriptorTable(Kernel_i386.GDT);
 
     KernelLogText(LOG_DEBUG, TEXT("[InitializeMemoryManager] Loading GDT"));
 
-    LoadGlobalDescriptorTable((PHYSICAL)(Kernel_i386.GDT), GDT_SIZE - 1);
+    LoadGlobalDescriptorTable((PHYSICAL)Kernel_i386.GDT, GDT_SIZE - 1);
 
     // Log GDT contents
     for (U32 i = 0; i < 3; i++) {

--- a/kernel/source/Segment.c
+++ b/kernel/source/Segment.c
@@ -42,33 +42,31 @@ void InitSegmentDescriptor(LPSEGMENTDESCRIPTOR This, U32 Type) {
 void InitGlobalDescriptorTable(LPSEGMENTDESCRIPTOR Table) {
     KernelLogText(LOG_DEBUG, TEXT("[InitGlobalDescriptorTable] Enter"));
 
-    LPSEGMENTDESCRIPTOR LinTable = (LPSEGMENTDESCRIPTOR) MapPhysicalPage(Table);
+    MemorySet(Table, 0, GDT_SIZE);
 
-    MemorySet(LinTable, 0, GDT_SIZE);
+    InitSegmentDescriptor(&Table[1], GDT_TYPE_CODE);
+    Table[1].Privilege = GDT_PRIVILEGE_KERNEL;
 
-    InitSegmentDescriptor(&LinTable[1], GDT_TYPE_CODE);
-    LinTable[1].Privilege = GDT_PRIVILEGE_KERNEL;
+    InitSegmentDescriptor(&Table[2], GDT_TYPE_DATA);
+    Table[2].Privilege = GDT_PRIVILEGE_KERNEL;
 
-    InitSegmentDescriptor(&LinTable[2], GDT_TYPE_DATA);
-    LinTable[2].Privilege = GDT_PRIVILEGE_KERNEL;
+    InitSegmentDescriptor(&Table[3], GDT_TYPE_CODE);
+    Table[3].Privilege = GDT_PRIVILEGE_USER;
 
-    InitSegmentDescriptor(&LinTable[3], GDT_TYPE_CODE);
-    LinTable[3].Privilege = GDT_PRIVILEGE_USER;
+    InitSegmentDescriptor(&Table[4], GDT_TYPE_DATA);
+    Table[4].Privilege = GDT_PRIVILEGE_USER;
 
-    InitSegmentDescriptor(&LinTable[4], GDT_TYPE_DATA);
-    LinTable[4].Privilege = GDT_PRIVILEGE_USER;
+    InitSegmentDescriptor(&Table[5], GDT_TYPE_CODE);
+    Table[5].Privilege = GDT_PRIVILEGE_KERNEL;
+    Table[5].OperandSize = GDT_OPERANDSIZE_16;
+    Table[5].Granularity = GDT_GRANULAR_1B;
+    SetSegmentDescriptorLimit(&Table[5], N_1MB_M1);
 
-    InitSegmentDescriptor(&LinTable[5], GDT_TYPE_CODE);
-    LinTable[5].Privilege = GDT_PRIVILEGE_KERNEL;
-    LinTable[5].OperandSize = GDT_OPERANDSIZE_16;
-    LinTable[5].Granularity = GDT_GRANULAR_1B;
-    SetSegmentDescriptorLimit(&LinTable[5], N_1MB_M1);
-
-    InitSegmentDescriptor(&LinTable[6], GDT_TYPE_DATA);
-    LinTable[6].Privilege = GDT_PRIVILEGE_KERNEL;
-    LinTable[6].OperandSize = GDT_OPERANDSIZE_16;
-    LinTable[6].Granularity = GDT_GRANULAR_1B;
-    SetSegmentDescriptorLimit(&LinTable[6], N_1MB_M1);
+    InitSegmentDescriptor(&Table[6], GDT_TYPE_DATA);
+    Table[6].Privilege = GDT_PRIVILEGE_KERNEL;
+    Table[6].OperandSize = GDT_OPERANDSIZE_16;
+    Table[6].Granularity = GDT_GRANULAR_1B;
+    SetSegmentDescriptorLimit(&Table[6], N_1MB_M1);
 
     KernelLogText(LOG_DEBUG, TEXT("[InitGlobalDescriptorTable] Exit"));
 }


### PR DESCRIPTION
## Summary
- Reserve a permanent linear region for the GDT and map physical pages with fixed mappings
- Initialize the GDT directly in its linear mapping and load it via that address

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66a329dc8330895a0334cc0fcaac