### PR TITLE
Initialize task segment storage

### DIFF
--- a/kernel/include/Memory.h
+++ b/kernel/include/Memory.h
@@ -20,6 +20,9 @@
 // Initializes the memory manager
 void InitializeMemoryManager(void);
 
+// Sets up task state segments and per-task descriptors
+void InitializeTaskSegments(void);
+
 // Uses a temp page table to get access to a random physical page
 LINEAR MapPhysicalPage(PHYSICAL Physical);
 

--- a/kernel/source/Kernel.c
+++ b/kernel/source/Kernel.c
@@ -395,6 +395,9 @@ void InitializeKernel(void) {
     InitializeMemoryManager();
     KernelLogText(LOG_VERBOSE, TEXT("[KernelMain] Memory manager initialized"));
 
+    InitializeTaskSegments();
+    KernelLogText(LOG_VERBOSE, TEXT("[KernelMain] Task segments initialized"));
+
     //-------------------------------------
     // Check data integrity
 

--- a/kernel/source/Memory.c
+++ b/kernel/source/Memory.c
@@ -1074,3 +1074,26 @@ void InitializeMemoryManager(void) {
 }
 
 /***************************************************************************/
+
+void InitializeTaskSegments(void) {
+    KernelLogText(LOG_DEBUG, TEXT("[InitializeTaskSegments] Enter"));
+
+    Kernel_i386.TSS = (LPTASKSTATESEGMENT)AllocRegion(
+        0,
+        0,
+        sizeof(TASKSTATESEGMENT) * NUM_TASKS,
+        ALLOC_PAGES_COMMIT | ALLOC_PAGES_READWRITE);
+
+    if (Kernel_i386.TSS == NULL) {
+        KernelLogText(LOG_ERROR, TEXT("[InitializeTaskSegments] AllocRegion for TSS failed"));
+        DO_THE_SLEEPING_BEAUTY;
+    }
+
+    Kernel_i386.TTD = (LPTASKTSSDESCRIPTOR)(Kernel_i386.GDT + GDT_NUM_BASE_DESCRIPTORS);
+
+    KernelLogText(LOG_DEBUG, TEXT("[InitializeTaskSegments] TSS = %X"), Kernel_i386.TSS);
+    KernelLogText(LOG_DEBUG, TEXT("[InitializeTaskSegments] TTD = %X"), Kernel_i386.TTD);
+    KernelLogText(LOG_DEBUG, TEXT("[InitializeTaskSegments] Exit"));
+}
+
+/***************************************************************************/


### PR DESCRIPTION
## Summary
- allocate linear task state segment region
- link per-task descriptor pointer to GDT and expose initializer
- invoke task segment setup before creating kernel tasks

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: ❌ Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6ec618048330a493dcc979373e0d