### PR TITLE
Pass boot parameters to kernel

### DIFF
--- a/boot-qemu-hd/source/vbr-payload-a.asm
+++ b/boot-qemu-hd/source/vbr-payload-a.asm
@@ -5,6 +5,7 @@
 
 BITS 16
 ORIGIN equ 0x8000
+KERNEL_LOAD_ADDRESS      equ 0x00020000
 
 section .start
 global _start
@@ -324,6 +325,11 @@ StubJumpToImage:
     mov         si, Text_JumpingToPM
     call        PrintString
 
+    xor         ebx, ebx               ; Prepare EBX and select page 0
+    mov         ah, 0x03               ; BIOS get cursor position
+    int         0x10
+    mov         bx, dx                 ; BL = X, BH = Y
+
     mov         eax, [ebp + 8]      ; GDTR
     lgdt        [eax]
 
@@ -352,9 +358,9 @@ ProtectedEntryPoint:
     mov         cr0, eax
     jmp         $+2                ; Pipeline flush
 
-    ; Jump to loaded image
-    mov         eax, [ebp + 16]    ; KernelEntryVA
-    jmp         eax
+    mov         ecx, [ebp + 16]    ; KernelEntryVA
+    mov         eax, KERNEL_LOAD_ADDRESS
+    jmp         ecx
 
     hlt
 .hang:

--- a/kernel/include/Kernel.h
+++ b/kernel/include/Kernel.h
@@ -161,7 +161,7 @@ BOOL GetCPUInformation(LPCPUINFORMATION);
 U32 ClockTask(LPVOID);
 U32 GetPhysicalMemoryUsed(void);
 void TestProcess(void);
-void InitializeKernel(void);
+void InitializeKernel(U32 ImageAddress, U8 CursorX, U8 CursorY);
 
 /***************************************************************************/
 

--- a/kernel/source/Kernel.c
+++ b/kernel/source/Kernel.c
@@ -349,7 +349,14 @@ void LoadDriver(LPDRIVER Driver, LPCSTR Name) {
 
 /***************************************************************************/
 
-void InitializeKernel(void) {
+static U32 KernelImageAddress;
+static U8 KernelCursorX;
+static U8 KernelCursorY;
+
+void InitializeKernel(U32 ImageAddress, U8 CursorX, U8 CursorY) {
+    KernelImageAddress = ImageAddress;
+    KernelCursorX = CursorX;
+    KernelCursorY = CursorY;
     // PROCESSINFO ProcessInfo;
     // TASKINFO TaskInfo;
 

--- a/kernel/source/Main.c
+++ b/kernel/source/Main.c
@@ -23,11 +23,18 @@ KERNELSTARTUPINFO KernelStartup = {
 // The entry point in paged protected mode
 
 void KernelMain(void) {
+    U32 ImageAddress;
+    U8 CursorX;
+    U8 CursorY;
+
+    __asm__ __volatile__("movl %%eax, %0" : "=r"(ImageAddress));
+    __asm__ __volatile__("movb %%bl, %0" : "=r"(CursorX));
+    __asm__ __volatile__("movb %%bh, %0" : "=r"(CursorY));
 
     //--------------------------------------
-    // Main intialization routine
+    // Main initialization routine
 
-    InitializeKernel();
+    InitializeKernel(ImageAddress, CursorX, CursorY);
 
     //--------------------------------------
     // Enter the idle task

--- a/kernel/source/Process.c
+++ b/kernel/source/Process.c
@@ -67,7 +67,7 @@ void InitializeKernelProcess(void) {
     TaskInfo.Header.Size = sizeof(TASKINFO);
     TaskInfo.Header.Version = EXOS_ABI_VERSION;
     TaskInfo.Header.Flags = 0;
-    TaskInfo.Func = InitializeKernel;
+    TaskInfo.Func = (TASKFUNC)InitializeKernel;
     TaskInfo.StackSize = TASK_MINIMUM_STACK_SIZE;
     TaskInfo.Priority = TASK_PRIORITY_LOWEST;
     TaskInfo.Flags = 0;


### PR DESCRIPTION
## Summary
- pass loaded image address and console cursor position to the kernel via registers
- forward EAX/EBX to `InitializeKernel` and extend its signature to accept them

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3f42ff3483308a2878aa029a9993