### PR TITLE
Fix task switch stack usage

### DIFF
--- a/kernel/source/asm/System.asm
+++ b/kernel/source/asm/System.asm
@@ -707,14 +707,14 @@ SwitchToTask :
 
     push        ebp
     mov         ebp, esp
-    sub         esp, 6                      ; reserve 6 bytes for far pointer: [offset(4)][selector(2)]
+    sub         esp, 8                      ; reserve space for far pointer
 
-    mov         eax, [ebp+(PBN+0)]
-    mov         dword [ebp-(LBN+6)], 0
-    mov         word [ebp-(LBN+2)], ax
-    jmp         far dword [ebp-(LBN+6)]
+    mov         eax, [ebp+PBN]
+    mov         dword [esp], 0              ; offset
+    mov         word [esp+4], ax            ; selector
+    jmp         far dword [esp]
 
-    add         esp, 6
+    add         esp, 8
     pop         ebp
     ret
 


### PR DESCRIPTION
## Summary
- reserve stack space for far pointer in SwitchToTask
- load selector via stack and perform far jump from safe region

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/1-setup-deps.sh` *(fails: Invalid response from proxy)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68acc01cf74c8330af0edfa1b5cd8720