### PR TITLE
Add TOML parser and enforce case-sensitive file names

### DIFF
--- a/kernel/include/File.h
+++ b/kernel/include/File.h
@@ -39,6 +39,9 @@ U32 DeleteFile(LPFILEOPENINFO);
 U32 CreateFolder(LPFILEOPENINFO);
 U32 DeleteFolder(LPFILEOPENINFO);
 
+LPVOID FileReadAll(LPCSTR, LPU32);
+U32 FileWriteAll(LPCSTR, LPCVOID, U32);
+
 /***************************************************************************/
 
 #endif

--- a/kernel/include/TOML.h
+++ b/kernel/include/TOML.h
@@ -1,0 +1,36 @@
+/***************************************************************************\
+
+    EXOS Kernel
+    Copyright (c) 1999-2025 Jango73
+    All rights reserved
+
+\***************************************************************************/
+
+#ifndef TOML_H_INCLUDED
+#define TOML_H_INCLUDED
+
+/***************************************************************************/
+
+#include "Base.h"
+
+/***************************************************************************/
+
+typedef struct tag_TOMLITEM {
+    LPSTR Key;
+    LPSTR Value;
+    struct tag_TOMLITEM* Next;
+} TOMLITEM, *LPTOMLITEM;
+
+typedef struct tag_TOML {
+    LPTOMLITEM First;
+} TOML, *LPTOML;
+
+/***************************************************************************/
+
+LPTOML TomlParse(LPCSTR Source);
+LPCSTR TomlGet(LPTOML Toml, LPCSTR Path);
+void TomlFree(LPTOML Toml);
+
+/***************************************************************************/
+
+#endif

--- a/kernel/source/FAT16.c
+++ b/kernel/source/FAT16.c
@@ -433,7 +433,7 @@ static BOOL LocateFile(LPFAT16FILESYSTEM FileSystem, LPCSTR Path, LPFATFILELOC F
             if ((DirEntry->Cluster) && (DirEntry->Attributes & FAT_ATTR_VOLUME) == 0 && (DirEntry->Name[0] != 0xE5)) {
                 DecodeFileName(DirEntry, Name);
 
-                if (StringCompareNC(Component, TEXT("*")) == 0 || StringCompareNC(Component, Name) == 0) {
+                if (StringCompare(Component, TEXT("*")) == 0 || StringCompare(Component, Name) == 0) {
                     if (Path[PathIndex] == STR_NULL) {
                         FileLoc->DataCluster = DirEntry->Cluster;
 

--- a/kernel/source/FAT32.c
+++ b/kernel/source/FAT32.c
@@ -880,7 +880,7 @@ static BOOL LocateFile(LPFAT32FILESYSTEM FileSystem, LPCSTR Path, LPFATFILELOC F
                 (DirEntry->Name[0] != 0xE5)) {
                 DecodeFileName(DirEntry, Name);
 
-                if (StringCompareNC(Component, TEXT("*")) == 0 || StringCompareNC(Component, Name) == 0) {
+                if (StringCompare(Component, TEXT("*")) == 0 || StringCompare(Component, Name) == 0) {
                     if (Path[PathIndex] == STR_NULL) {
                         FileLoc->DataCluster = (((U32)DirEntry->ClusterLow) | (((U32)DirEntry->ClusterHigh) << 16));
 
@@ -1038,7 +1038,7 @@ static U32 CreateFolder(LPFILEINFO File) {
                 (DirEntry->Name[0] != 0xE5)) {
                 DecodeFileName(DirEntry, Name);
 
-                if (StringCompareNC(Component, TEXT("*")) == 0 || StringCompareNC(Component, Name) == 0) {
+                if (StringCompare(Component, TEXT("*")) == 0 || StringCompare(Component, Name) == 0) {
                     if (File->Name[PathIndex] == STR_NULL) {
                         if (DirEntry->Attributes & FAT_ATTR_FOLDER) {
                             return DF_ERROR_SUCCESS;

--- a/kernel/source/File.c
+++ b/kernel/source/File.c
@@ -11,6 +11,7 @@
 
 #include "../include/File.h"
 
+#include "../include/Heap.h"
 #include "../include/Kernel.h"
 #include "../include/Process.h"
 
@@ -47,7 +48,7 @@ LPFILE OpenFile(LPFILEOPENINFO Info) {
 
         AlreadyOpen = (LPFILE)Node;
 
-        if (StringCompareNC(AlreadyOpen->Name, Info->Name) == 0) {
+        if (StringCompare(AlreadyOpen->Name, Info->Name) == 0) {
             if (AlreadyOpen->OwnerTask == GetCurrentTask()) {
                 if (AlreadyOpen->OpenFlags == Info->Flags) {
                     File = AlreadyOpen;
@@ -93,7 +94,7 @@ LPFILE OpenFile(LPFILEOPENINFO Info) {
 
     for (Node = Kernel.FileSystem->First; Node; Node = Node->Next) {
         FileSystem = (LPFILESYSTEM)Node;
-        if (StringCompareNC(FileSystem->Name, Volume) == 0) {
+        if (StringCompare(FileSystem->Name, Volume) == 0) {
             FoundFileSystem = 1;
             break;
         }
@@ -253,6 +254,88 @@ U32 GetFileSize(LPFILE File) {
     UnlockMutex(&(File->Mutex));
 
     return Size;
+}
+
+/***************************************************************************/
+
+LPVOID FileReadAll(LPCSTR Name, LPU32 Size) {
+    FILEOPENINFO OpenInfo;
+    FILEOPERATION FileOp;
+    LPFILE File = NULL;
+    LPVOID Buffer = NULL;
+
+    //-------------------------------------
+    // Check validity of parameters
+
+    if (Name == NULL) return NULL;
+    if (Size == NULL) return NULL;
+
+    //-------------------------------------
+    // Open the file
+
+    OpenInfo.Header.Size = sizeof(FILEOPENINFO);
+    OpenInfo.Name = (LPSTR)Name;
+    OpenInfo.Flags = FILE_OPEN_READ;
+    File = OpenFile(&OpenInfo);
+
+    if (File == NULL) return NULL;
+
+    //-------------------------------------
+    // Allocate buffer and read content
+
+    *Size = GetFileSize(File);
+    Buffer = HeapAlloc(*Size + 1);
+
+    if (Buffer != NULL) {
+        FileOp.Header.Size = sizeof(FILEOPERATION);
+        FileOp.File = File;
+        FileOp.Buffer = Buffer;
+        FileOp.NumBytes = *Size;
+        ReadFile(&FileOp);
+        ((LPSTR)Buffer)[*Size] = STR_NULL;
+    }
+
+    CloseFile(File);
+
+    return Buffer;
+}
+
+/***************************************************************************/
+
+U32 FileWriteAll(LPCSTR Name, LPCVOID Buffer, U32 Size) {
+    FILEOPENINFO OpenInfo;
+    FILEOPERATION FileOp;
+    LPFILE File = NULL;
+    U32 BytesWritten = 0;
+
+    //-------------------------------------
+    // Check validity of parameters
+
+    if (Name == NULL) return 0;
+    if (Buffer == NULL) return 0;
+
+    //-------------------------------------
+    // Open the file
+
+    OpenInfo.Header.Size = sizeof(FILEOPENINFO);
+    OpenInfo.Name = (LPSTR)Name;
+    OpenInfo.Flags = FILE_OPEN_WRITE | FILE_OPEN_CREATE_ALWAYS | FILE_OPEN_TRUNCATE;
+    File = OpenFile(&OpenInfo);
+
+    if (File == NULL) return 0;
+
+    //-------------------------------------
+    // Write the buffer to the file
+
+    FileOp.Header.Size = sizeof(FILEOPERATION);
+    FileOp.File = File;
+    FileOp.Buffer = (LPVOID)Buffer;
+    FileOp.NumBytes = Size;
+    BytesWritten = WriteFile(&FileOp);
+
+    CloseFile(File);
+
+    return BytesWritten;
 }
 
 /***************************************************************************/

--- a/kernel/source/TOML.c
+++ b/kernel/source/TOML.c
@@ -1,0 +1,160 @@
+// TOML.c
+
+/***************************************************************************\
+
+    EXOS Kernel
+    Copyright (c) 1999-2025 Jango73
+    All rights reserved
+
+\***************************************************************************/
+
+#include "../include/TOML.h"
+
+#include "../include/Heap.h"
+#include "../include/String.h"
+
+/***************************************************************************/
+
+LPTOML TomlParse(LPCSTR Source) {
+    LPTOML Toml = NULL;
+    LPTOMLITEM Last = NULL;
+    STR Section[0x80];
+    U32 Index = 0;
+
+    Toml = (LPTOML)HeapAlloc(sizeof(TOML));
+    if (Toml == NULL) return NULL;
+    Toml->First = NULL;
+
+    Section[0] = STR_NULL;
+    if (Source == NULL) return Toml;
+
+    while (Source[Index]) {
+        STR Line[0x100];
+        U32 LineLen = 0;
+        LPSTR Ptr = NULL;
+        LPSTR Comment = NULL;
+        LPSTR Equal = NULL;
+        LPSTR Key = NULL;
+        LPSTR Value = NULL;
+        LPSTR End = NULL;
+        STR FullKey[0x100];
+        LPTOMLITEM Item = NULL;
+
+        while (Source[Index] && Source[Index] != '\n') {
+            if (LineLen < 0xFF) {
+                Line[LineLen++] = Source[Index];
+            }
+            Index++;
+        }
+
+        if (Source[Index] == '\n') Index++;
+        Line[LineLen] = STR_NULL;
+
+        Comment = StringFindChar(Line, '#');
+        if (Comment) *Comment = STR_NULL;
+
+        Ptr = Line;
+        while (*Ptr == ' ' || *Ptr == '\t') Ptr++;
+        if (*Ptr == STR_NULL) continue;
+
+        if (*Ptr == '[') {
+            Ptr++;
+            End = StringFindChar(Ptr, ']');
+            if (End) *End = STR_NULL;
+            StringCopy(Section, Ptr);
+            continue;
+        }
+
+        Equal = StringFindChar(Ptr, '=');
+        if (Equal == NULL) continue;
+        *Equal = STR_NULL;
+        Key = Ptr;
+        Value = Equal + 1;
+
+        End = Key + StringLength(Key);
+        while (End > Key && (End[-1] == ' ' || End[-1] == '\t')) {
+            End[-1] = STR_NULL;
+            End--;
+        }
+
+        while (*Value == ' ' || *Value == '\t') Value++;
+        End = Value + StringLength(Value);
+        while (End > Value && (End[-1] == ' ' || End[-1] == '\t' || End[-1] == '\r')) {
+            End[-1] = STR_NULL;
+            End--;
+        }
+
+        if (*Value == '\"') {
+            Value++;
+            End = StringFindChar(Value, '\"');
+            if (End) *End = STR_NULL;
+        }
+
+        FullKey[0] = STR_NULL;
+        if (!StringEmpty(Section)) {
+            StringCopy(FullKey, Section);
+            StringConcat(FullKey, ".");
+        }
+        StringConcat(FullKey, Key);
+
+        Item = (LPTOMLITEM)HeapAlloc(sizeof(TOMLITEM));
+        if (Item == NULL) continue;
+        Item->Next = NULL;
+        Item->Key = (LPSTR)HeapAlloc(StringLength(FullKey) + 1);
+        Item->Value = (LPSTR)HeapAlloc(StringLength(Value) + 1);
+        if (Item->Key == NULL || Item->Value == NULL) {
+            if (Item->Key) HeapFree(Item->Key);
+            if (Item->Value) HeapFree(Item->Value);
+            HeapFree(Item);
+            continue;
+        }
+        StringCopy(Item->Key, FullKey);
+        StringCopy(Item->Value, Value);
+
+        if (Toml->First == NULL) {
+            Toml->First = Item;
+        } else {
+            Last->Next = Item;
+        }
+        Last = Item;
+    }
+
+    return Toml;
+}
+
+/***************************************************************************/
+
+LPCSTR TomlGet(LPTOML Toml, LPCSTR Path) {
+    LPTOMLITEM Item = NULL;
+
+    if (Toml == NULL) return NULL;
+    if (Path == NULL) return NULL;
+
+    for (Item = Toml->First; Item; Item = Item->Next) {
+        if (StringCompare(Item->Key, Path) == 0) {
+            return Item->Value;
+        }
+    }
+
+    return NULL;
+}
+
+/***************************************************************************/
+
+void TomlFree(LPTOML Toml) {
+    LPTOMLITEM Item = NULL;
+    LPTOMLITEM Next = NULL;
+
+    if (Toml == NULL) return;
+
+    for (Item = Toml->First; Item; Item = Next) {
+        Next = Item->Next;
+        if (Item->Key) HeapFree(Item->Key);
+        if (Item->Value) HeapFree(Item->Value);
+        HeapFree(Item);
+    }
+
+    HeapFree(Toml);
+}
+
+/***************************************************************************/

--- a/kernel/source/XFS.c
+++ b/kernel/source/XFS.c
@@ -322,8 +322,8 @@ static BOOL LocateFile(LPXFSFILESYSTEM FileSystem, LPCSTR Path, LPXFSFILELOC Fil
             }
 
             if (FileRec->ClusterTable > 0 && FileRec->ClusterTable != XFS_CLUSTER_END) {
-                if (StringCompareNC(Component->Name, TEXT("*")) == 0 ||
-                    StringCompareNC(Component->Name, FileRec->Name) == 0) {
+                if (StringCompare(Component->Name, TEXT("*")) == 0 ||
+                    StringCompare(Component->Name, FileRec->Name) == 0) {
                     if (Component->Next == NULL) {
                         FileLoc->DataCluster = FileRec->ClusterTable;
                         goto Out_Success;


### PR DESCRIPTION
## Summary
- add lightweight TOML parser with query helpers
- introduce FileReadAll and FileWriteAll utilities
- remove case-insensitive file name comparisons across file systems

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68ae08096804833092135028b5b87df9