### PR TITLE
Add executable attribute to file systems

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -848,13 +848,15 @@ Implements real mode call support and exit routines.
 
 ### Stub.asm
 
-Boot stub that transitions from the DOS loader to protected mode.
+Minimal 32-bit entry stub used when the kernel is loaded directly.
+It stores an "EXOS" magic string and jumps to the C kernel.
 
-#### Functions in Stub.asm
+#### Symbols in Stub.asm
 
-- StartAbsolute: Absolute entry point invoked by the DOS loader.
-- ProtectedModeEntry: Sets up segments and stack before jumping to the C kernel.
-- KernelStack: Preallocated kernel stack space.
+- stub_base: Start of the stub and reference for the magic string.
+- Magic: Four-byte identifier used to validate the stub.
+- start: Entry point that writes a debug byte to the serial port,
+  calls `KernelMain` and halts if it returns.
 
 ### Sys.asm
 

--- a/kernel/include/FileSystem.h
+++ b/kernel/include/FileSystem.h
@@ -62,6 +62,7 @@
 #define FS_ATTR_READONLY 0x0002
 #define FS_ATTR_HIDDEN 0x0004
 #define FS_ATTR_SYSTEM 0x0008
+#define FS_ATTR_EXECUTABLE 0x0010
 
 /***************************************************************************/
 

--- a/kernel/include/XFS.h
+++ b/kernel/include/XFS.h
@@ -99,6 +99,7 @@ typedef struct tag_XFSFILEREC {
 #define XFS_ATTR_SYSTEM BIT_2
 #define XFS_ATTR_ARCHIVE BIT_3
 #define XFS_ATTR_HIDDEN BIT_4
+#define XFS_ATTR_EXECUTABLE BIT_5
 
 /***************************************************************************/
 

--- a/kernel/source/FAT16.c
+++ b/kernel/source/FAT16.c
@@ -363,6 +363,8 @@ static void TranslateFileInfo(LPFATDIRENTRY DirEntry, LPFATFILE File) {
         File->Header.Attributes |= FS_ATTR_SYSTEM;
     }
 
+    File->Header.Attributes |= FS_ATTR_EXECUTABLE;
+
     //-------------------------------------
     // Translate the size
 

--- a/kernel/source/FAT32.c
+++ b/kernel/source/FAT32.c
@@ -948,6 +948,8 @@ static void TranslateFileInfo(LPFATDIRENTRY_EXT DirEntry, LPFATFILE File) {
         File->Header.Attributes |= FS_ATTR_SYSTEM;
     }
 
+    File->Header.Attributes |= FS_ATTR_EXECUTABLE;
+
     //-------------------------------------
     // Translate the size
 

--- a/kernel/source/Shell.c
+++ b/kernel/source/Shell.c
@@ -359,6 +359,10 @@ static void ListFile(LPFILE File) {
         ConsolePrint(TEXT("S"));
     else
         ConsolePrint(TEXT("-"));
+    if (File->Attributes & FS_ATTR_EXECUTABLE)
+        ConsolePrint(TEXT("X"));
+    else
+        ConsolePrint(TEXT("-"));
 
     ConsolePrint(Text_NewLine);
 }

--- a/kernel/source/XFS.c
+++ b/kernel/source/XFS.c
@@ -595,6 +595,10 @@ static void TranslateFileInfo(LPXFSFILEREC FileRec, LPXFSFILE File) {
         File->Header.Attributes |= FS_ATTR_SYSTEM;
     }
 
+    if (FileRec->Attributes & XFS_ATTR_EXECUTABLE) {
+        File->Header.Attributes |= FS_ATTR_EXECUTABLE;
+    }
+
     //-------------------------------------
     // Translate the size
 


### PR DESCRIPTION
## Summary
- add FS_ATTR_EXECUTABLE and XFS_ATTR_EXECUTABLE flags
- map executable flag in XFS driver and default it for FAT16/FAT32
- correct Kernel.md section about Stub.asm

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaca7ddbc8330b7b76c01a02e9b00