### PR TITLE
Fix file mutex lock order

### DIFF
--- a/kernel/source/File.c
+++ b/kernel/source/File.c
@@ -37,9 +37,8 @@ LPFILE OpenFile(LPFILEOPENINFO Info) {
     LockMutex(MUTEX_FILE, INFINITY);
 
     for (Node = Kernel.File->First; Node; Node = Node->Next) {
-        LockMutex(&(AlreadyOpen->Mutex), INFINITY);  // ???????????????
-
         AlreadyOpen = (LPFILE)Node;
+        LockMutex(&(AlreadyOpen->Mutex), INFINITY);
 
         if (StringCompare(AlreadyOpen->Name, Info->Name) == 0) {
             if (AlreadyOpen->OwnerTask == GetCurrentTask()) {


### PR DESCRIPTION
## Summary
- Assign file pointer before locking its mutex to avoid undefined behavior

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `timeout 15 ./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68af4135d88883308201e20c14de5877