### PR TITLE
Add string formatting helper

### DIFF
--- a/kernel/include/Log.h
+++ b/kernel/include/Log.h
@@ -28,7 +28,6 @@
 /***************************************************************************/
 
 void InitKernelLog(void);
-void VarKernelPrintNumber(I32 Number, I32 Base, I32 FieldWidth, I32 Precision, I32 Flags);
 void KernelPrintString(LPCSTR Text);
 void KernelPrintStringNoMutex(LPCSTR Text);
 void KernelLogText(U32, LPCSTR, ...);

--- a/kernel/include/String.h
+++ b/kernel/include/String.h
@@ -13,6 +13,7 @@
 /***************************************************************************/
 
 #include "Base.h"
+#include "VarArg.h"
 
 /***************************************************************************/
 // Flags for format printing
@@ -56,6 +57,9 @@ U32 StringToU32(LPCSTR);
 /***************************************************************************/
 
 LPSTR NumberToString(LPSTR Text, I32 Number, I32 Base, I32 Size, I32 Precision, I32 Type);
+
+void StringPrintFormatArgs(LPSTR Destination, LPCSTR Format, VarArgList Args);
+void StringPrintFormat(LPSTR Destination, LPCSTR Format, ...);
 
 /***************************************************************************/
 

--- a/kernel/source/Fault.c
+++ b/kernel/source/Fault.c
@@ -20,6 +20,12 @@
 /************************************************************************/
 // Fault logging helpers (selector-aware)
 
+static void KernelPrintHex(U32 Number) {
+    STR Text[32];
+    StringPrintFormat(Text, TEXT("%X"), Number);
+    KernelPrintString(Text);
+}
+
 static void LogSelectorFromErrorCode(LPCSTR Prefix, U32 Err) {
     U16 sel = (U16)(Err & 0xFFFFu);
     U16 idx = SELECTOR_INDEX(sel);
@@ -205,9 +211,9 @@ void DebugExceptionHandler_MinProbe(void) {
     unsigned char trap = *(volatile unsigned char*)(unsigned long)(base + 0x64);
 
     KernelPrintString(TEXT("[#DB] TSS base="));
-    VarKernelPrintNumber(base, 16, 0, 0, 0);
+    KernelPrintHex(base);
     KernelPrintString(TEXT(" Trap@+0x64="));
-    VarKernelPrintNumber(trap, 16, 0, 0, 0);
+    KernelPrintHex(trap);
     KernelPrintString(Text_NewLine);
 }
 
@@ -239,26 +245,26 @@ void DebugExceptionHandler(LPINTERRUPTFRAME Frame) {
 
     U32 gdtr = GetGDTR();
     KernelPrintString(TEXT("GDTR : "));
-    VarKernelPrintNumber(gdtr, 16, 0, 0, 0);
+    KernelPrintHex(gdtr);
     KernelPrintString(Text_Space);
 
     U32 ldtr = GetLDTR();
     KernelPrintString(TEXT("LDTR : "));
-    VarKernelPrintNumber(ldtr, 16, 0, 0, 0);
+    KernelPrintHex(ldtr);
     KernelPrintString(Text_Space);
 
     SELECTOR tr = GetTaskRegister();
 
     KernelPrintString(TEXT("Index : "));
-    VarKernelPrintNumber((U32)SELECTOR_INDEX(tr), 16, 0, 0, 0);
+    KernelPrintHex((U32)SELECTOR_INDEX(tr));
     KernelPrintString(Text_Space);
 
     KernelPrintString(TEXT("TI : "));
-    VarKernelPrintNumber((U32)SELECTOR_TI(tr), 16, 0, 0, 0);
+    KernelPrintHex((U32)SELECTOR_TI(tr));
     KernelPrintString(Text_Space);
 
     KernelPrintString(TEXT("RPL : "));
-    VarKernelPrintNumber((U32)SELECTOR_RPL(tr), 16, 0, 0, 0);
+    KernelPrintHex((U32)SELECTOR_RPL(tr));
     KernelPrintString(Text_Space);
 
     KernelPrintString(Text_NewLine);
@@ -408,16 +414,16 @@ void StackFaultHandler(LPINTERRUPTFRAME Frame) {
 
 static void LogGPError(U32 err) {
     KernelPrintString(TEXT("[#GP] err="));
-    VarKernelPrintNumber(err, 16, 0, 0, 0);
+    KernelPrintHex(err);
     KernelPrintString(TEXT(" ext="));
-    VarKernelPrintNumber(err & 1, 16, 0, 0, 0);
+    KernelPrintHex(err & 1);
     KernelPrintString(TEXT(" idt="));
-    VarKernelPrintNumber((err >> 1) & 1, 16, 0, 0, 0);
+    KernelPrintHex((err >> 1) & 1);
     KernelPrintString(TEXT(" ti="));
-    VarKernelPrintNumber((err >> 2) & 1, 16, 0, 0, 0);
+    KernelPrintHex((err >> 2) & 1);
     U32 sel = err & 0xFFFC;
     KernelPrintString(TEXT(" sel="));
-    VarKernelPrintNumber(sel, 16, 0, 0, 0);
+    KernelPrintHex(sel);
     KernelPrintString(Text_NewLine);
 }
 

--- a/kernel/source/String.c
+++ b/kernel/source/String.c
@@ -457,8 +457,6 @@ static int SkipAToI(LPCSTR* Format) {
         (*Format)++;
     }
 
-    (*Format)--;
-
     return Result;
 }
 


### PR DESCRIPTION
## Summary
- factorize formatted string building into `StringPrintFormat` helpers
- refactor log and console printing to reuse shared formatter
- simplify fault logging with a hex printing helper

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b02928573c8330a2bdf127212b1333