### PR TITLE
Refine clock ISR stack handling for safe task switching

### DIFF
--- a/kernel/source/Schedule.c
+++ b/kernel/source/Schedule.c
@@ -174,7 +174,9 @@ void Scheduler(LPTRAPFRAME Frame) {
                         // KernelLogText(LOG_DEBUG, TEXT("[Scheduler] Set ESP0 = %X"), Next->SysStackTop);
                         Kernel_i386.TSS->ESP0 = Next->SysStackTop;
 
-                        *Frame = Next->Context;
+                        U32 OldESP = Frame->ESP;  // Keep original kernel stack
+                        *Frame = Next->Context;   // Load next task context
+                        Frame->ESP = OldESP;      // Restore kernel ESP for ISR cleanup
 
                         TaskList.Current = Next;
                     }

--- a/kernel/source/asm/Interrupt-a.asm
+++ b/kernel/source/asm/Interrupt-a.asm
@@ -263,7 +263,15 @@ Interrupt_Clock :
     push    es
     push    fs
     push    gs
-    pushad
+    push    eax
+    push    ecx
+    push    edx
+    push    ebx
+    sub     esp, 4               ; reserve slot for ESP
+    mov     [esp], esp           ; store current stack pointer
+    push    ebp
+    push    esi
+    push    edi
 
     call    ClockHandler
 
@@ -275,7 +283,14 @@ Interrupt_Clock :
     mov     al, INTERRUPT_DONE
     out     INTERRUPT_CONTROL, al
 
-    popad
+    pop     edi
+    pop     esi
+    pop     ebp
+    add     esp, 4               ; discard saved ESP
+    pop     ebx
+    pop     edx
+    pop     ecx
+    pop     eax
     pop     gs
     pop     fs
     pop     es


### PR DESCRIPTION
## Summary
- Replace pushad/popad in clock interrupt with explicit register saves that leave ESP untouched
- Preserve kernel stack pointer in Scheduler when loading next task context

## Testing
- `make`
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Booting from Hard Disk, but no OS output)*


------
https://chatgpt.com/codex/tasks/task_e_68b175813eac8330b3f494427253f3a9