### PR TITLE
Fix keyboard controller command handling

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -553,7 +553,7 @@ Implements the PC keyboard driver and key buffering.
 
 - KeyboardWait: Waits for the controller input buffer to clear.
 - KeyboardACK: Checks if the keyboard acknowledged a command.
-- SendKeyboardCommand: Sends a command and data byte to the keyboard.
+- SendKeyboardCommand: Sends a command to the keyboard controller or device.
 - ScanCodeToKeyCode: Converts hardware scan codes to key codes.
 - ScanCodeToKeyCode_E0: Handles extended scan code prefix E0.
 - ScanCodeToKeyCode_E1: Handles extended scan code prefix E1.


### PR DESCRIPTION
## Summary
- handle controller commands via `KEYBOARD_COMMAND` without ACK
- fix keyboard initialization to send `KSC_ENABLE` correctly
- document controller vs device command behavior

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68b18048d6788330ae21826204bb04b4