### PR TITLE
Align trapframe and context switch with xv6

### DIFF
--- a/kernel/include/I386.h
+++ b/kernel/include/I386.h
@@ -241,23 +241,31 @@ typedef struct tag_TASKSTATESEGMENT {
 
 // 60-byte context saved by the interrupt stub (ring 0 only)
 typedef struct tag_TRAPFRAME {
-    U32 EDI;
-    U32 ESI;
-    U32 EBP;
-    U32 ESP;
-    U32 EBX;
-    U32 EDX;
-    U32 ECX;
-    U32 EAX;
-    U32 GS;
-    U32 FS;
-    U32 ES;
-    U32 DS;
-    U32 EIP;
-    U32 CS;
+    U32 Edi;
+    U32 Esi;
+    U32 Ebp;
+    U32 Oesp;
+    U32 Ebx;
+    U32 Edx;
+    U32 Ecx;
+    U32 Eax;
+    U16 Gs;
+    U16 Padding1;
+    U16 Fs;
+    U16 Padding2;
+    U16 Es;
+    U16 Padding3;
+    U16 Ds;
+    U16 Padding4;
+    U32 TrapNo;
+    U32 Err;
+    U32 Eip;
+    U16 Cs;
+    U16 Padding5;
     U32 EFlags;
-    U32 UserESP;
-    U32 SS;
+    U32 Esp;
+    U16 Ss;
+    U16 Padding6;
 } TRAPFRAME, *LPTRAPFRAME;
 
 /************************************************************************/

--- a/kernel/include/System.h
+++ b/kernel/include/System.h
@@ -65,7 +65,7 @@ extern U32 GetPageDirectory(void);
 extern void SetPageDirectory(PHYSICAL Base);
 extern void InvalidatePage(U32 Address);
 extern void FlushTLB(void);
-extern U32 SwitchToTask(U32);
+extern void SwitchToTask(LPTRAPFRAME *Old, LPTRAPFRAME New);
 extern U32 TaskRunner(void);
 extern U32 ClearTaskState(void);
 extern U32 PeekConsoleWord(U32);

--- a/kernel/source/Schedule.c
+++ b/kernel/source/Schedule.c
@@ -177,9 +177,9 @@ LPTRAPFRAME Scheduler(LPTRAPFRAME Frame) {
             ", EAX : %X, EBX : %X, ECX %X, EDX %X\n"
             ", ESI : %X, EDI : %X, EBP %X, ESP %X\n"
         ),
-        Frame->DS, Frame->ES, Frame->FS, Frame->GS,
-        Frame->ESI, Frame->EDI, Frame->EBP, Frame->ESP,
-        Frame->EAX, Frame->EBX, Frame->ECX, Frame->EDX
+        Frame->Ds, Frame->Es, Frame->Fs, Frame->Gs,
+        Frame->Esi, Frame->Edi, Frame->Ebp, Frame->Esp,
+        Frame->Eax, Frame->Ebx, Frame->Ecx, Frame->Edx
         );
     #endif
 

--- a/kernel/source/Task.c
+++ b/kernel/source/Task.c
@@ -260,18 +260,17 @@ LPTASK CreateTask(LPPROCESS Process, LPTASKINFO Info) {
     Task->SysStackTop = SysStackPointer;
 
     MemorySet(&(Task->Context), 0, sizeof(TRAPFRAME));
-    Task->Context.EIP = (U32)TaskRunner;
-    Task->Context.EAX = (U32)Task->Parameter;
-    Task->Context.EBX = (U32)Task->Function;
-    Task->Context.ESP = StackPointer;
-    Task->Context.EBP = StackPointer;
-    Task->Context.CS = CodeSelector;
-    Task->Context.DS = DataSelector;
-    Task->Context.ES = DataSelector;
-    Task->Context.FS = DataSelector;
-    Task->Context.GS = DataSelector;
-    Task->Context.SS = DataSelector;
-    Task->Context.UserESP = StackPointer;
+    Task->Context.Eip = (U32)TaskRunner;
+    Task->Context.Eax = (U32)Task->Parameter;
+    Task->Context.Ebx = (U32)Task->Function;
+    Task->Context.Esp = StackPointer;
+    Task->Context.Ebp = StackPointer;
+    Task->Context.Cs = (U16)CodeSelector;
+    Task->Context.Ds = (U16)DataSelector;
+    Task->Context.Es = (U16)DataSelector;
+    Task->Context.Fs = (U16)DataSelector;
+    Task->Context.Gs = (U16)DataSelector;
+    Task->Context.Ss = (U16)DataSelector;
     Task->Context.EFlags = EFLAGS_IF | EFLAGS_A1;
 
     if (Info->Flags & TASK_CREATE_MAIN) {

--- a/kernel/source/asm/Interrupt-a.asm
+++ b/kernel/source/asm/Interrupt-a.asm
@@ -258,14 +258,8 @@ Interrupt_AlignmentCheck :
 ; Error code : No
 
 Interrupt_Clock :
-    pop     eax                     ; EIP
-    pop     ecx                     ; CS
-    pop     edx                     ; EFLAGS
-    push    dword 0                 ; Placeholder for SS
-    push    dword 0                 ; Placeholder for UserESP
-    push    edx                     ; EFLAGS
-    push    ecx                     ; CS
-    push    eax                     ; EIP
+    push    dword 0                 ; Error code
+    push    dword 32                ; Trap number
     push    ds
     push    es
     push    fs
@@ -290,13 +284,7 @@ Interrupt_Clock :
     pop     fs
     pop     es
     pop     ds
-    mov     eax, [esp]
-    mov     ecx, [esp + 4]
-    mov     edx, [esp + 8]
-    add     esp, 8
-    mov     [esp], eax
-    mov     [esp + 4], ecx
-    mov     [esp + 8], edx
+    add     esp, 8                  ; Remove trap number and error code
     iretd
 
 ;--------------------------------------

--- a/kernel/source/asm/System.asm
+++ b/kernel/source/asm/System.asm
@@ -706,21 +706,21 @@ FlushTLB :
 
 SwitchToTask :
 
-    push        ebp
-    mov         ebp, esp
-    sub         esp, 8                      ; reserve space for far pointer
+    mov     eax, [esp + 4]        ; Pointer to save old stack
+    mov     edx, [esp + 8]        ; New stack pointer
 
-    xor         eax, eax
-    mov         dr6, eax
-    mov         dr7, eax
+    push    ebp                   ; Save callee-saved registers
+    push    ebx
+    push    esi
+    push    edi
 
-    mov         eax, [ebp+PBN]
-    mov         dword [esp], 0              ; offset
-    mov         word [esp+4], ax            ; selector
-    jmp         far dword [esp]
+    mov     [eax], esp            ; Save old stack pointer
+    mov     esp, edx              ; Switch to new stack
 
-    add         esp, 8
-    pop         ebp
+    pop     edi                   ; Restore callee-saved registers
+    pop     esi
+    pop     ebx
+    pop     ebp
     ret
 
 ;--------------------------------------


### PR DESCRIPTION
## Summary
- Restructure TRAPFRAME to match xv6 layout with segment paddings
- Build clock interrupt frame like xv6 and adjust context switch assembly
- Initialize tasks and scheduler logging for new trapframe fields

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fa997a908330931ad3997ab6555c