### PR TITLE
Scope disk index per type

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -481,7 +481,8 @@ Handles mounting of disk partitions and path manipulation.
 #### Functions in FileSystem.c
 
 - GetNumFileSystems: Returns the number of available file systems.
-- GetDefaultFileSystemName: Builds a default name for new file systems.
+- GetDefaultFileSystemName: Builds a default name for new file systems. Disk index
+  starts at 0 for each disk type (hd0, rd0, ...).
 - MountPartition_Extended: Mounts an extended partition.
 - MountDiskPartitions: Scans a disk and mounts each partition.
 - DecompPath: Splits a path into its individual components.

--- a/kernel/source/FileSystem.c
+++ b/kernel/source/FileSystem.c
@@ -40,21 +40,28 @@ U32 GetNumFileSystems(void) { return Kernel.FileSystem->NumItems; }
 /***************************************************************************/
 
 /*
-    Build a default volume name using zero-based disk and partition indexes.
+    Build a default volume name using zero-based disk and partition indexes
+    per disk type.
 */
 BOOL GetDefaultFileSystemName(LPSTR Name, LPPHYSICALDISK Disk, U32 PartIndex) {
     STR Temp[12];
     LPLISTNODE Node;
+    LPPHYSICALDISK CurrentDisk;
     U32 DiskIndex = 0;
 
+    // Find the index of this disk among disks of the same type
     for (Node = Kernel.Disk->First; Node; Node = Node->Next) {
-        if ((LPPHYSICALDISK)Node == Disk) break;
-        DiskIndex++;
+        CurrentDisk = (LPPHYSICALDISK)Node;
+        if (CurrentDisk == Disk) break;
+        if (CurrentDisk->Driver->Type == Disk->Driver->Type) DiskIndex++;
     }
 
     switch (Disk->Driver->Type) {
         case DRIVER_TYPE_RAMDISK:
             StringCopy(Name, TEXT("rd"));
+            break;
+        case DRIVER_TYPE_FLOPPYDISK:
+            StringCopy(Name, TEXT("fd"));
             break;
         default:
             StringCopy(Name, TEXT("hd"));


### PR DESCRIPTION
## Summary
- Build default file system names with per-type disk indexes
- Document per-type disk indexing for file system naming

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68b31941b5308330ac56bf786d4347d2