### PR TITLE
Wrap ConsolePrint strings with TEXT macro

### DIFF
--- a/kernel/source/test/Test-Regex.c
+++ b/kernel/source/test/Test-Regex.c
@@ -16,7 +16,7 @@ static void TestRegex(LPCSTR Pattern, LPCSTR Text) {
     REGEX Rx;
     BOOL Ok = RegexCompile(Pattern, &Rx);
     if (!Ok) {
-        ConsolePrint("Regex compile failed: %s\n", Pattern);
+        ConsolePrint(TEXT("Regex compile failed: %s\n"), Pattern);
         return;
     }
 
@@ -24,19 +24,19 @@ static void TestRegex(LPCSTR Pattern, LPCSTR Text) {
     U32 Start = 0, End = 0;
     BOOL Search = RegexSearch(&Rx, Text, &Start, &End);
 
-    ConsolePrint("Pattern: \"%s\"\n", Pattern);
-    ConsolePrint("Text   : \"%s\"\n", Text);
-    ConsolePrint("Match? : %s\n", Match ? "YES" : "NO");
+    ConsolePrint(TEXT("Pattern: \"%s\"\n"), Pattern);
+    ConsolePrint(TEXT("Text   : \"%s\"\n"), Text);
+    ConsolePrint(TEXT("Match? : %s\n"), Match ? TEXT("YES") : TEXT("NO"));
     if (Search) {
-        ConsolePrint("Search : YES (span %u..%u)\n", Start, End);
+        ConsolePrint(TEXT("Search : YES (span %u..%u)\n"), Start, End);
     } else {
-        ConsolePrint("Search : NO\n");
+        ConsolePrint(TEXT("Search : NO\n"));
     }
-    ConsolePrint("\n");
+    ConsolePrint(TEXT("\n"));
 }
 
 void RegexSelfTest(void) {
-    ConsolePrint("=== REGEX SELF TEST ===\n");
+    ConsolePrint(TEXT("=== REGEX SELF TEST ===\n"));
 
     TestRegex("^[A-Za-z_][A-Za-z0-9_]*$", "Hello_123");
     TestRegex("^[A-Za-z_][A-Za-z0-9_]*$", "123Oops");
@@ -53,5 +53,5 @@ void RegexSelfTest(void) {
     TestRegex("a[0-9]b", "ab");
     TestRegex("a[^0-9]b", "axb");
 
-    ConsolePrint("=== END SELF TEST ===\n");
+    ConsolePrint(TEXT("=== END SELF TEST ===\n"));
 }


### PR DESCRIPTION
## Summary
- silence ConsolePrint warnings in regex tests by wrapping literals with `TEXT`

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68b33acb3d8483309bef52d20d20f390