### PR TITLE
Run configured executables at shell startup

### DIFF
--- a/kernel/include/FileSystem.h
+++ b/kernel/include/FileSystem.h
@@ -60,6 +60,7 @@
 #define DF_FS_MOUNTOBJECT (DF_FIRSTFUNC + 18)
 #define DF_FS_UNMOUNTOBJECT (DF_FIRSTFUNC + 19)
 #define DF_FS_PATHEXISTS (DF_FIRSTFUNC + 20)
+#define DF_FS_FILEEXISTS (DF_FIRSTFUNC + 21)
 
 /***************************************************************************/
 

--- a/kernel/include/Process.h
+++ b/kernel/include/Process.h
@@ -61,8 +61,7 @@ typedef struct tag_SECURITY {
 
 // Macro to initialize a security
 
-#define EMPTY_SECURITY \
-    { ID_SECURITY, 1, NULL, NULL, 0, 0, PERMISSION_NONE }
+#define EMPTY_SECURITY {ID_SECURITY, 1, NULL, NULL, 0, 0, PERMISSION_NONE}
 
 /***************************************************************************\
 
@@ -210,6 +209,7 @@ LINEAR GetProcessHeap(LPPROCESS);
 void DumpProcess(LPPROCESS);
 void InitSecurity(LPSECURITY);
 BOOL CreateProcess(LPPROCESSINFO);
+BOOL Spawn(LPCSTR, LPCSTR);
 
 /***************************************************************************/
 // Functions in Task.c

--- a/kernel/source/Process.c
+++ b/kernel/source/Process.c
@@ -52,6 +52,12 @@ PROCESS KernelProcess = {
 
 /***************************************************************************/
 
+/**
+ * @brief Initialize the kernel process and main task.
+ *
+ * Prepare the kernel heap, set up the kernel process fields and create the
+ * primary kernel task.
+ */
 void InitializeKernelProcess(void) {
     TASKINFO TaskInfo;
 
@@ -106,6 +112,11 @@ void InitializeKernelProcess(void) {
 
 /***************************************************************************/
 
+/**
+ * @brief Allocate and initialize a new user process structure.
+ *
+ * @return Pointer to the new PROCESS or NULL on failure.
+ */
 LPPROCESS NewProcess(void) {
     LPPROCESS This = NULL;
 
@@ -141,6 +152,12 @@ LPPROCESS NewProcess(void) {
 
 /***************************************************************************/
 
+/**
+ * @brief Create a new process from an executable file.
+ *
+ * @param Info Pointer to a PROCESSINFO describing the executable.
+ * @return TRUE on success, FALSE on failure.
+ */
 BOOL CreateProcess(LPPROCESSINFO Info) {
     EXECUTABLEINFO ExecutableInfo;
     TASKINFO TaskInfo;
@@ -373,6 +390,13 @@ Out:
 
 /***************************************************************************/
 
+/**
+ * @brief Create a new process using only a file name and command line.
+ *
+ * @param FileName Name of the executable file to run.
+ * @param CommandLine Command line passed to the process or NULL.
+ * @return TRUE on success, FALSE otherwise.
+ */
 BOOL Spawn(LPCSTR FileName, LPCSTR CommandLine) {
     PROCESSINFO ProcessInfo;
 
@@ -391,6 +415,12 @@ BOOL Spawn(LPCSTR FileName, LPCSTR CommandLine) {
 
 /***************************************************************************/
 
+/**
+ * @brief Retrieve the heap base address of a process.
+ *
+ * @param Process Process to inspect, or NULL for the current process.
+ * @return Linear address of the process heap.
+ */
 LINEAR GetProcessHeap(LPPROCESS Process) {
     LINEAR HeapBase = NULL;
 
@@ -407,6 +437,11 @@ LINEAR GetProcessHeap(LPPROCESS Process) {
 
 /***************************************************************************/
 
+/**
+ * @brief Output process information to the kernel log.
+ *
+ * @param Process Process to dump. Nothing is logged if NULL.
+ */
 void DumpProcess(LPPROCESS Process) {
     if (Process == NULL) return;
 
@@ -426,6 +461,11 @@ void DumpProcess(LPPROCESS Process) {
 
 /***************************************************************************/
 
+/**
+ * @brief Initialize a SECURITY structure.
+ *
+ * @param This SECURITY structure to initialize.
+ */
 void InitSecurity(LPSECURITY This) {
     if (This == NULL) return;
 

--- a/kernel/source/Process.c
+++ b/kernel/source/Process.c
@@ -373,6 +373,24 @@ Out:
 
 /***************************************************************************/
 
+BOOL Spawn(LPCSTR FileName, LPCSTR CommandLine) {
+    PROCESSINFO ProcessInfo;
+
+    ProcessInfo.Header.Size = sizeof(PROCESSINFO);
+    ProcessInfo.Header.Version = EXOS_ABI_VERSION;
+    ProcessInfo.Header.Flags = 0;
+    ProcessInfo.Flags = 0;
+    ProcessInfo.FileName = FileName;
+    ProcessInfo.CommandLine = CommandLine;
+    ProcessInfo.StdOut = NULL;
+    ProcessInfo.StdIn = NULL;
+    ProcessInfo.StdErr = NULL;
+
+    return CreateProcess(&ProcessInfo);
+}
+
+/***************************************************************************/
+
 LINEAR GetProcessHeap(LPPROCESS Process) {
     LINEAR HeapBase = NULL;
 

--- a/kernel/source/SerialMouse.c
+++ b/kernel/source/SerialMouse.c
@@ -305,7 +305,7 @@ static U32 MouseInitialize(void) {
     //-------------------------------------
     //
 
-    KernelLogText(LOG_VERBOSE, TEXT("Mouse found on COM1: %c%c"), Sig1, Sig2);
+    KernelLogText(LOG_VERBOSE, TEXT("[MouseInitialize] Mouse found on COM1: %c%c"), Sig1, Sig2);
 
     //-------------------------------------
     // Enable the mouse's IRQ

--- a/kernel/source/Shell.c
+++ b/kernel/source/Shell.c
@@ -1029,7 +1029,6 @@ static void RunConfiguredExecutables(void) {
     STR IndexText[0x10];
     LPCSTR ExecutablePath;
     FILEINFO FileInfo;
-    LPFILE File;
 
     KernelLogText(LOG_DEBUG, TEXT("[RunConfiguredExecutables] Enter"));
 
@@ -1051,9 +1050,7 @@ static void RunConfiguredExecutables(void) {
         FileInfo.Attributes = MAX_U32;
         StringCopy(FileInfo.Name, ExecutablePath);
 
-        File = (LPFILE)Kernel.SystemFS->Driver->Command(DF_FS_OPENFILE, (U32)&FileInfo);
-        if (File != NULL) {
-            Kernel.SystemFS->Driver->Command(DF_FS_CLOSEFILE, (U32)File);
+        if (Kernel.SystemFS->Driver->Command(DF_FS_FILEEXISTS, (U32)&FileInfo)) {
             Spawn(ExecutablePath, NULL);
         } else {
             KernelLogText(LOG_WARNING, TEXT("[RunConfiguredExecutables] Executable not found : %s"), ExecutablePath);

--- a/kernel/source/Shell.c
+++ b/kernel/source/Shell.c
@@ -689,6 +689,11 @@ static void CMD_md(LPSHELLCONTEXT Context) { MakeFolder(Context); }
 
 /***************************************************************************/
 
+/**
+ * @brief Launch an executable specified on the command line.
+ *
+ * @param Context Shell context containing parsed arguments.
+ */
 static void CMD_run(LPSHELLCONTEXT Context) {
     STR FileName[MAX_PATH_NAME];
 
@@ -1023,6 +1028,12 @@ static void CMD_test(LPSHELLCONTEXT Context) {
 
 /***************************************************************************/
 
+/**
+ * @brief Launch executables listed in the kernel configuration.
+ *
+ * Each [[Run]] item of exos.toml is checked and the executable is spawned
+ * if present on disk.
+ */
 static void RunConfiguredExecutables(void) {
     U32 ConfigIndex = 0;
     STR Key[0x100];
@@ -1064,6 +1075,12 @@ static void RunConfiguredExecutables(void) {
 
 /***************************************************************************/
 
+/**
+ * @brief Parse and execute a single command line.
+ *
+ * @param Context Shell context to fill and execute.
+ * @return TRUE to continue the shell loop, FALSE otherwise.
+ */
 static BOOL ParseCommand(LPSHELLCONTEXT Context) {
     U32 Length;
     U32 Index;
@@ -1123,6 +1140,15 @@ static BOOL ParseCommand(LPSHELLCONTEXT Context) {
 
 /***************************************************************************/
 
+/**
+ * @brief Entry point for the interactive shell.
+ *
+ * Initializes the shell context, runs configured executables and processes
+ * user commands until termination.
+ *
+ * @param Param Unused parameter.
+ * @return Exit code of the shell.
+ */
 U32 Shell(LPVOID Param) {
     UNUSED(Param);
     SHELLCONTEXT Context;

--- a/kernel/source/Shell.c
+++ b/kernel/source/Shell.c
@@ -33,6 +33,7 @@
 #include "../include/List.h"
 #include "../include/Log.h"
 #include "../include/Path.h"
+#include "../include/Process.h"
 #include "../include/String.h"
 #include "../include/StringArray.h"
 #include "../include/System.h"
@@ -95,7 +96,6 @@ static void CMD_inp(LPSHELLCONTEXT);
 static void CMD_reboot(LPSHELLCONTEXT);
 static void CMD_test(LPSHELLCONTEXT);
 static BOOL QualifyFileName(LPSHELLCONTEXT, LPCSTR, LPSTR);
-static void CreateProcessSimple(LPCSTR, LPCSTR);
 static void RunConfiguredExecutables(void);
 
 /***************************************************************************/
@@ -696,7 +696,7 @@ static void CMD_run(LPSHELLCONTEXT Context) {
 
     if (StringLength(Context->Command)) {
         if (QualifyFileName(Context, Context->Command, FileName)) {
-            CreateProcessSimple(FileName, NULL);
+            Spawn(FileName, NULL);
         }
     }
 }
@@ -1023,24 +1023,6 @@ static void CMD_test(LPSHELLCONTEXT Context) {
 
 /***************************************************************************/
 
-static void CreateProcessSimple(LPCSTR FileName, LPCSTR CommandLine) {
-    PROCESSINFO ProcessInfo;
-
-    ProcessInfo.Header.Size = sizeof(PROCESSINFO);
-    ProcessInfo.Header.Version = EXOS_ABI_VERSION;
-    ProcessInfo.Header.Flags = 0;
-    ProcessInfo.Flags = 0;
-    ProcessInfo.FileName = FileName;
-    ProcessInfo.CommandLine = CommandLine;
-    ProcessInfo.StdOut = NULL;
-    ProcessInfo.StdIn = NULL;
-    ProcessInfo.StdErr = NULL;
-
-    CreateProcess(&ProcessInfo);
-}
-
-/***************************************************************************/
-
 static void RunConfiguredExecutables(void) {
     U32 ConfigIndex = 0;
     STR Key[0x100];
@@ -1067,7 +1049,7 @@ static void RunConfiguredExecutables(void) {
         StringCopy(PathCheck.SubFolder, ExecutablePath);
 
         if (Kernel.SystemFS->Driver->Command(DF_FS_PATHEXISTS, (U32)&PathCheck)) {
-            CreateProcessSimple(ExecutablePath, NULL);
+            Spawn(ExecutablePath, NULL);
         } else {
             KernelLogText(LOG_WARNING, TEXT("[RunConfiguredExecutables] Executable not found : %s"), ExecutablePath);
         }

--- a/kernel/source/SystemFS.c
+++ b/kernel/source/SystemFS.c
@@ -107,16 +107,15 @@ static LPSYSTEMFSFILE NewSystemFile(LPCSTR Name, LPSYSTEMFSFILE Parent) {
     LPSYSTEMFSFILE Node = (LPSYSTEMFSFILE)HeapAlloc(sizeof(SYSTEMFSFILE));
     if (Node == NULL) return NULL;
 
-    *Node = (SYSTEMFSFILE){
-        .ID = ID_FILE,
-        .References = 1,
-        .Next = NULL,
-        .Prev = NULL,
-        .Children = NewList(NULL, HeapAlloc, HeapFree),
-        .Parent = Parent,
-        .Mounted = NULL,
-        .Attributes = FS_ATTR_FOLDER | FS_ATTR_READONLY,
-        .Creation = {0}};
+    *Node = (SYSTEMFSFILE){.ID = ID_FILE,
+                           .References = 1,
+                           .Next = NULL,
+                           .Prev = NULL,
+                           .Children = NewList(NULL, HeapAlloc, HeapFree),
+                           .Parent = Parent,
+                           .Mounted = NULL,
+                           .Attributes = FS_ATTR_FOLDER | FS_ATTR_READONLY,
+                           .Creation = {0}};
 
     GetLocalTime(&(Node->Creation));
 
@@ -363,6 +362,18 @@ static BOOL PathExists(LPFS_PATHCHECK Control) {
     Node->Mounted->Driver->Command(DF_FS_CLOSEFILE, (U32)Mounted);
 
     return Result;
+}
+
+static BOOL FileExists(LPFILEINFO Info) {
+    LPSYSFSFILE File;
+
+    if (Info == NULL) return FALSE;
+
+    File = OpenFile(Info);
+    if (File == NULL) return FALSE;
+
+    CloseFile(File);
+    return TRUE;
 }
 
 /***************************************************************************/
@@ -758,6 +769,8 @@ U32 SystemFSCommands(U32 Function, U32 Parameter) {
             return UnmountObject((LPFS_UNMOUNT_CONTROL)Parameter);
         case DF_FS_PATHEXISTS:
             return (U32)PathExists((LPFS_PATHCHECK)Parameter);
+        case DF_FS_FILEEXISTS:
+            return (U32)FileExists((LPFILEINFO)Parameter);
         case DF_FS_OPENFILE:
             return (U32)OpenFile((LPFILEINFO)Parameter);
         case DF_FS_OPENNEXT:


### PR DESCRIPTION
## Summary
- add support to launch executables listed in kernel config `[[Run]]` sections
- execute these programs on shell startup if their path exists

## Testing
- `make` *(fails: i686-elf-gcc: command not found)*
- `./scripts/6-1-start-qemu-hd-nogfx.sh` *(fails: Image not found: bin/exos.img)*

------
https://chatgpt.com/codex/tasks/task_e_68b343ac38e483309f4f7b0f19cfc979