### PR TITLE
Ensure DHCP updates network context address

### DIFF
--- a/kernel/include/ARPContext.h
+++ b/kernel/include/ARPContext.h
@@ -73,6 +73,7 @@ void ARP_Tick(LPDEVICE Device);
 int ARP_Resolve(LPDEVICE Device, U32 TargetIPv4_Be, U8 OutMacAddress[6]);
 void ARP_DumpCache(LPDEVICE Device);
 void ARP_OnEthernetFrame(LPDEVICE Device, const U8* Frame, U32 Length);
+void ARP_SetLocalAddress(LPDEVICE Device, U32 LocalIPv4_Be);
 U32 ARP_RegisterNotification(LPDEVICE Device, U32 EventID, NOTIFICATION_CALLBACK Callback, LPVOID UserData);
 U32 ARP_UnregisterNotification(LPDEVICE Device, U32 EventID, NOTIFICATION_CALLBACK Callback, LPVOID UserData);
 

--- a/kernel/source/ARP.c
+++ b/kernel/source/ARP.c
@@ -578,6 +578,26 @@ void ARP_Initialize(LPDEVICE Device, U32 LocalIPv4_Be) {
 
 /************************************************************************/
 
+void ARP_SetLocalAddress(LPDEVICE Device, U32 LocalIPv4_Be) {
+    LPARP_CONTEXT Context;
+
+    if (Device == NULL) return;
+
+    Context = ARP_GetContext(Device);
+    if (Context == NULL) return;
+
+    Context->LocalIPv4_Be = LocalIPv4_Be;
+
+    U32 IpHost = Ntohl(LocalIPv4_Be);
+    DEBUG(TEXT("[ARP_SetLocalAddress] Local IPv4 updated to %u.%u.%u.%u"),
+          (IpHost >> 24) & 0xFF,
+          (IpHost >> 16) & 0xFF,
+          (IpHost >> 8) & 0xFF,
+          IpHost & 0xFF);
+}
+
+/************************************************************************/
+
 void ARP_Destroy(LPDEVICE Device) {
     LPARP_CONTEXT Context;
 

--- a/kernel/source/DHCP.c
+++ b/kernel/source/DHCP.c
@@ -413,6 +413,13 @@ void DHCP_OnUDPPacket(U32 SourceIP, U16 SourcePort, U16 DestinationPort, const U
                                 LPNETWORK_DEVICE_CONTEXT NetCtx = (LPNETWORK_DEVICE_CONTEXT)Node;
                                 SAFE_USE_VALID_ID(NetCtx, ID_NETWORKDEVICE) {
                                     if ((LPDEVICE)NetCtx->Device == g_DHCPDevice) {
+                                        NetCtx->LocalIPv4_Be = Context->OfferedIP_Be;
+                                        U32 AssignedHost = Ntohl(Context->OfferedIP_Be);
+                                        DEBUG(TEXT("[DHCP_OnUDPPacket] Updated network context IP to %u.%u.%u.%u"),
+                                              (AssignedHost >> 24) & 0xFF,
+                                              (AssignedHost >> 16) & 0xFF,
+                                              (AssignedHost >> 8) & 0xFF,
+                                              AssignedHost & 0xFF);
                                         NetCtx->IsReady = TRUE;
                                         DEBUG(TEXT("[DHCP_OnUDPPacket] Network device marked as ready"));
                                         break;

--- a/kernel/source/IPv4.c
+++ b/kernel/source/IPv4.c
@@ -303,6 +303,8 @@ void IPv4_SetNetworkConfig(LPDEVICE Device, U32 LocalIPv4_Be, U32 NetmaskBe, U32
     Context->NetmaskBe = NetmaskBe;
     Context->DefaultGatewayBe = DefaultGatewayBe;
 
+    ARP_SetLocalAddress(Device, LocalIPv4_Be);
+
     U32 IP = Ntohl(LocalIPv4_Be);
     U32 Mask = Ntohl(NetmaskBe);
     U32 Gateway = Ntohl(DefaultGatewayBe);


### PR DESCRIPTION
## Summary
- propagate DHCP-assigned IPv4 addresses to the network device context
- add an ARP helper and invoke it from IPv4_SetNetworkConfig to keep ARP in sync

## Testing
- ./scripts/4-5-build-debug.sh *(fails: i686-elf-gcc not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0586c07c8330b3903601f39aa3ee