### PR TITLE
Release process-owned kernel references during cleanup

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -432,6 +432,7 @@ EXOS implements a lifecycle management system for both processes and tasks that 
   - Calls `DeleteTask()` which frees stacks, message queues, etc.
   - Updates process task counts and marks processes dead if needed
 - Second phase: Processes all `PROCESS_STATUS_DEAD` processes
+  - Calls `ReleaseProcessKernelObjects()` to drop references held by the process on every kernel-managed list
   - Calls `DeleteProcessCommit()` which frees page directories, heaps, etc.
   - Removes process from global process list
 
@@ -452,6 +453,7 @@ EXOS implements a lifecycle management system for both processes and tasks that 
 **Mutex Protection:**
 - Process list operations are protected by `MUTEX_PROCESS`
 - Task list operations are protected by `MUTEX_KERNEL`
+- `ReleaseProcessKernelObjects()` requires `MUTEX_KERNEL` to be locked while iterating kernel lists
 - Task count updates are atomic to prevent race conditions
 
 **Resource Cleanup Order:**

--- a/kernel/include/Kernel.h
+++ b/kernel/include/Kernel.h
@@ -196,6 +196,7 @@ void TestProcess(void);
 void InitializeKernel(void);
 void StoreObjectTerminationState(LPVOID Object, U32 ExitCode);
 BOOL ObjectExists(HANDLE Object);
+void ReleaseProcessKernelObjects(LPPROCESS Process);
 
 /***************************************************************************/
 // Functions in Segment.c


### PR DESCRIPTION
## Summary
- add ReleaseProcessKernelObjects to release process-owned objects across all kernel lists
- invoke the new cleanup helper from DeleteDeadTasksAndProcesses while preserving mutex ordering
- document the additional cleanup step in the kernel lifecycle guide

## Testing
- ./scripts/4-5-build-debug.sh *(fails: i686-elf-gcc not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd314cae588330b8a029c9f6d9925f