### PR TITLE
Fix TCP receive buffering edge cases

### DIFF
--- a/kernel/include/Socket.h
+++ b/kernel/include/Socket.h
@@ -175,7 +175,7 @@ U32 SocketAddressGenericToInet(LPSOCKET_ADDRESS GenericAddress, LPSOCKET_ADDRESS
 
 // Internal functions
 void SocketTCPNotificationCallback(LPNOTIFICATION_DATA NotificationData, LPVOID UserData);
-void SocketTCPReceiveCallback(LPTCP_CONNECTION TCPConnection, const U8* Data, U32 DataLength);
+U32 SocketTCPReceiveCallback(LPTCP_CONNECTION TCPConnection, const U8* Data, U32 DataLength);
 void SocketDestructor(LPVOID Item);
 
 /************************************************************************/

--- a/kernel/include/TCP.h
+++ b/kernel/include/TCP.h
@@ -205,6 +205,7 @@ void TCP_ProcessDataConsumption(LPTCP_CONNECTION Connection, U32 DataConsumed);
 
 // Check if window update ACK should be sent based on hysteresis
 BOOL TCP_ShouldSendWindowUpdate(LPTCP_CONNECTION Connection);
+void TCP_HandleSocketDataConsumed(LPTCP_CONNECTION Connection, U32 BytesConsumed);
 
 // Utility functions
 U16 TCP_CalculateChecksum(TCP_HEADER* Header, const U8* Payload, U32 PayloadLength, U32 SourceIP, U32 DestinationIP);


### PR DESCRIPTION
## Summary
- clamp TCP receive acknowledgements to the bytes actually buffered and guard against out-of-order segments
- relax ACK sequence validation for duplicate acknowledgements while keeping control packets strict
- synchronize socket consumption with TCP window tracking through a dedicated helper

## Testing
- ./scripts/4-5-build-debug.sh *(fails: i686-elf-gcc not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd46a498a48330bcb48da01cb67a45