### PR TITLE
Add mutex initialization to device structures

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -507,12 +507,13 @@ The network stack is organized in five main layers with per-device context manag
 
 **Location:** `kernel/include/Device.h`, `kernel/source/Device.c`
 
-The network stack uses a device-based architecture where all network devices inherit from a common `DEVICE` structure that supports context storage and management.
+The network stack uses a device-based architecture where all network devices inherit from a common `DEVICE` structure that supports context storage and management. Every device embeds a mutex used to serialize access to shared state; drivers must call `InitMutex()` on the device instance before exposing it to other subsystems.
 
 **Device Structure:**
 ```c
 #define DEVICE_FIELDS       \
     LISTNODE_FIELDS         \
+    MUTEX Mutex;            \
     LPDRIVER Driver;        \
     LIST Contexts;
 

--- a/kernel/include/Device.h
+++ b/kernel/include/Device.h
@@ -30,11 +30,13 @@
 #include "Base.h"
 #include "List.h"
 #include "Driver.h"
+#include "Mutex.h"
 
 /***************************************************************************/
 
 #define DEVICE_FIELDS       \
     LISTNODE_FIELDS         \
+    MUTEX Mutex;            \
     LPDRIVER Driver;        \
     LIST Contexts;          \
     STR Name[MAX_FS_LOGICAL_NAME];

--- a/kernel/source/E1000.c
+++ b/kernel/source/E1000.c
@@ -665,6 +665,7 @@ static LPPCI_DEVICE E1000_Attach(LPPCI_DEVICE PciDevice) {
 
     MemorySet(Device, 0, sizeof(E1000DEVICE));
     MemoryCopy(Device, PciDevice, sizeof(PCI_DEVICE));
+    InitMutex(&(Device->Mutex));
 
     DEBUG(TEXT("[E1000_Attach] Device=%x, ID=%x, PciDevice->ID=%x"), Device, Device->ID, PciDevice->ID);
 

--- a/kernel/source/PCI.c
+++ b/kernel/source/PCI.c
@@ -444,6 +444,7 @@ void PCI_ScanBus(void) {
                     (U32)PciInfo.VendorID, (U32)PciInfo.DeviceID);
 
                 MemorySet(&PciDevice, 0, sizeof(PCI_DEVICE));
+                InitMutex(&(PciDevice.Mutex));
                 PciDevice.ID = ID_PCIDEVICE;
                 PciDevice.References = 1;
                 PciDevice.Driver = NULL;

--- a/kernel/source/SATA.c
+++ b/kernel/source/SATA.c
@@ -404,6 +404,7 @@ static LPPCI_DEVICE AHCIAttach(LPPCI_DEVICE PciDevice) {
 
     // Copy PCI device information to the heap-allocated structure
     MemoryCopy(Device, PciDevice, sizeof(PCI_DEVICE));
+    InitMutex(&(Device->Mutex));
     Device->Next = NULL;
     Device->Prev = NULL;
     Device->References = 1;


### PR DESCRIPTION
## Summary
- embed a mutex in the DEVICE base fields to guard shared state
- initialize the device mutex for PCI scan results and driver-created instances
- document the new synchronization requirement for device implementations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd7e5e17e08330adf7b23153c219df