### PR TITLE
Add immediate TCP ACK handling

### DIFF
--- a/kernel/include/TCP.h
+++ b/kernel/include/TCP.h
@@ -152,6 +152,7 @@ typedef struct tag_TCP_PACKET_EVENT {
     U32 PayloadLength;
     U32 SourceIP;
     U32 DestinationIP;
+    BOOL AckSent;            // Indicates if an ACK was already transmitted for this segment
 } TCP_PACKET_EVENT, *LPTCP_PACKET_EVENT;
 
 /************************************************************************/


### PR DESCRIPTION
## Summary
- send an immediate ACK for every received TCP segment by updating RecvNext and flushing the packet before the state machine runs
- extend TCP packet events with an ACK status so state actions skip duplicate acknowledgements while keeping RecvNext monotonic
- leave the window computation using the live receive buffer space to advertise accurate flow control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de703b33748330ad288cd30d3514ab