### PR TITLE
Adjust TCP zero-window ACK handling

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -692,6 +692,8 @@ TCP provides reliable connection-oriented communication using a state machine-ba
 - Sequence number management
 - Timer-based retransmission and TIME_WAIT handling
 - Checksum validation with IPv4 pseudo-header
+- Zero-window protection that keeps `RecvNext` unchanged while the receive buffer is full
+- Immediate window update ACKs emitted when the application consumes buffered data
 
 **Connection Structure:**
 ```c


### PR DESCRIPTION
## Summary
- keep TCP from advancing RecvNext when the receive window is exhausted so zero-window ACKs are stable
- trigger an immediate window-update ACK whenever the application consumes buffered data
- document the tightened zero-window behaviour in the kernel notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de90fc3d1083308c489ce521ecc4b5