### PR TITLE
Fix circular buffer growth calculations

### DIFF
--- a/kernel/source/CircularBuffer.c
+++ b/kernel/source/CircularBuffer.c
@@ -128,13 +128,10 @@ U32 CircularBuffer_Write(LPCIRCULAR_BUFFER Buffer, const U8* Data, U32 Length) {
     U32 AvailableSpace = Buffer->Size - Buffer->DataLength;
 
     if (Length > AvailableSpace) {
-        U32 Needed = Length - AvailableSpace;
-        if (Needed > 0) {
-            if (CircularBuffer_TryGrow(Buffer, Needed)) {
-                AvailableSpace = Buffer->Size - Buffer->DataLength;
-            } else {
-                Buffer->Overflowed = TRUE;
-            }
+        if (CircularBuffer_TryGrow(Buffer, Length)) {
+            AvailableSpace = Buffer->Size - Buffer->DataLength;
+        } else {
+            Buffer->Overflowed = TRUE;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the circular buffer grow logic considers the entire write length
- preserve overflow flagging when growth cannot satisfy the requested write

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de9fea0d48833098f2c5221e06cd21