### PR TITLE
Ensure processes track working directories for file operations

### DIFF
--- a/kernel/include/File.h
+++ b/kernel/include/File.h
@@ -54,6 +54,7 @@ U32 GetFileSize(LPFILE File);
 U32 DeleteFile(LPFILEOPENINFO FileOpenInfo);
 U32 CreateFolder(LPFILEOPENINFO FileOpenInfo);
 U32 DeleteFolder(LPFILEOPENINFO FileOpenInfo);
+BOOL QualifyFileName(LPCSTR BaseFolder, LPCSTR RawName, LPSTR FileName);
 
 LPVOID FileReadAll(LPCSTR, U32 *);
 U32 FileWriteAll(LPCSTR, LPCVOID, U32);

--- a/kernel/include/Process.h
+++ b/kernel/include/Process.h
@@ -76,6 +76,7 @@ struct tag_PROCESS {
     U32 ExitCode;            // This process' exit code
     STR FileName[MAX_PATH_NAME];
     STR CommandLine[MAX_PATH_NAME];
+    STR WorkFolder[MAX_PATH_NAME];
     U32 TaskCount;           // Number of active tasks in this process
     U64 UserID;              // Owner user
     LPUSERSESSION Session;   // User session

--- a/kernel/include/User.h
+++ b/kernel/include/User.h
@@ -287,6 +287,7 @@ typedef struct tag_PROCESSINFO {
     ABI_HEADER Header;
     U32 Flags;
     STR CommandLine[MAX_PATH_NAME];
+    STR WorkFolder[MAX_PATH_NAME];
     HANDLE StdOut;
     HANDLE StdIn;
     HANDLE StdErr;

--- a/kernel/source/SYSCall.c
+++ b/kernel/source/SYSCall.c
@@ -186,6 +186,7 @@ U32 SysCall_GetProcessInfo(U32 Parameter) {
 
             // Copy the command line
             StringCopy(Info->CommandLine, CurrentProcess->CommandLine);
+            StringCopy(Info->WorkFolder, CurrentProcess->WorkFolder);
 
             return DF_ERROR_SUCCESS;
         }


### PR DESCRIPTION
## Summary
- add WorkFolder storage to process structures and propagate it through process creation and syscalls
- move QualifyFileName into File.c and reuse it across the kernel and shell
- ensure OpenFile resolves relative paths against the current process working folder

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ded0db9b308330b8d6a566977e2a63