### PR TITLE
Pass shell work folder to Spawn

### DIFF
--- a/kernel/include/Process.h
+++ b/kernel/include/Process.h
@@ -76,6 +76,7 @@ struct tag_PROCESS {
     U32 ExitCode;            // This process' exit code
     STR FileName[MAX_PATH_NAME];
     STR CommandLine[MAX_PATH_NAME];
+    STR WorkFolder[MAX_PATH_NAME];
     U32 TaskCount;           // Number of active tasks in this process
     U64 UserID;              // Owner user
     LPUSERSESSION Session;   // User session
@@ -189,7 +190,7 @@ void KillProcess(LPPROCESS);
 void DeleteProcessCommit(LPPROCESS);
 void InitSecurity(LPSECURITY);
 BOOL CreateProcess(LPPROCESSINFO);
-U32 Spawn(LPCSTR);
+U32 Spawn(LPCSTR, LPCSTR);
 void SetProcessStatus(LPPROCESS Process, U32 Status);
 LINEAR GetProcessHeap(LPPROCESS);
 

--- a/kernel/include/User.h
+++ b/kernel/include/User.h
@@ -287,6 +287,7 @@ typedef struct tag_PROCESSINFO {
     ABI_HEADER Header;
     U32 Flags;
     STR CommandLine[MAX_PATH_NAME];
+    STR WorkFolder[MAX_PATH_NAME];
     HANDLE StdOut;
     HANDLE StdIn;
     HANDLE StdErr;

--- a/kernel/source/SYSCall.c
+++ b/kernel/source/SYSCall.c
@@ -186,6 +186,7 @@ U32 SysCall_GetProcessInfo(U32 Parameter) {
 
             // Copy the command line
             StringCopy(Info->CommandLine, CurrentProcess->CommandLine);
+            StringCopy(Info->WorkFolder, CurrentProcess->WorkFolder);
 
             return DF_ERROR_SUCCESS;
         }

--- a/kernel/source/Shell.c
+++ b/kernel/source/Shell.c
@@ -1537,6 +1537,7 @@ static BOOL SpawnExecutable(LPSHELLCONTEXT Context, LPCSTR CommandName, BOOL Bac
             ProcessInfo.Header.Flags = 0;
             ProcessInfo.Flags = 0;
             StringCopy(ProcessInfo.CommandLine, QualifiedCommandLine);
+            StringCopy(ProcessInfo.WorkFolder, Context->CurrentFolder);
             ProcessInfo.StdOut = NULL;
             ProcessInfo.StdIn = NULL;
             ProcessInfo.StdErr = NULL;
@@ -1547,7 +1548,7 @@ static BOOL SpawnExecutable(LPSHELLCONTEXT Context, LPCSTR CommandName, BOOL Bac
                 DEBUG(TEXT("Process started in background"));
             }
         } else {
-            U32 ExitCode = Spawn(QualifiedCommandLine);
+            U32 ExitCode = Spawn(QualifiedCommandLine, Context->CurrentFolder);
             return (ExitCode != MAX_U32);
         }
     }
@@ -1747,7 +1748,7 @@ static U32 ShellScriptCallFunction(LPCSTR FuncName, LPCSTR Argument, LPVOID User
         STR QualifiedCommandLine[MAX_PATH_NAME];
 
         if (QualifyCommandLine(Context, Argument, QualifiedCommandLine)) {
-            U32 ExitCode = Spawn(QualifiedCommandLine);
+            U32 ExitCode = Spawn(QualifiedCommandLine, Context->CurrentFolder);
             DEBUG(TEXT("[ShellScriptCallFunction] exec returned: %u"), ExitCode);
             return ExitCode;
         }


### PR DESCRIPTION
## Summary
- update the Spawn ABI to accept an explicit working directory parameter
- default the working directory to the parent when none is provided
- forward the shell's current folder when spawning foreground processes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df78cd05cc8330900be7092d4f2ff4