### PR TITLE
Track active filesystem partition

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -10,6 +10,15 @@ Be aware that it generates A LOT of COM2 output, the scheduler is called every 1
 
 To be completed.
 
+### File system globals
+
+The kernel tracks shared file system information in `Kernel.FileSystemInfo`.
+It currently stores the logical name of the partition flagged as active while
+MBR partitions are mounted. Disk drivers report an active partition through
+`FileSystemSetActivePartition`, which copies the mounted file system name into
+`Kernel.FileSystemInfo.ActivePartitionName` for later use (for example, in the
+shell).
+
 ## Startup sequence on HD (real HD on i386 or qemu-system-i386)
 
 Everything in this sequence runs in 16-bit real mode on i386+ processors.

--- a/kernel/include/FileSystem.h
+++ b/kernel/include/FileSystem.h
@@ -127,6 +127,13 @@ typedef struct tag_FILESYSTEM {
 } FILESYSTEM, *LPFILESYSTEM;
 
 /***************************************************************************/
+// Global file system state shared across the kernel
+
+typedef struct tag_FILESYSTEM_GLOBAL_INFO {
+    STR ActivePartitionName[MAX_FS_LOGICAL_NAME];
+} FILESYSTEM_GLOBAL_INFO, *LPFILESYSTEM_GLOBAL_INFO;
+
+/***************************************************************************/
 // The structure used by the folder commands
 // and the file open command
 
@@ -208,6 +215,7 @@ BOOL GetDefaultFileSystemName(LPSTR, LPPHYSICALDISK, U32);
 BOOL MountSystemFS(void);
 BOOL MountUserNodes(void);
 void InitializeFileSystems(void);
+void FileSystemSetActivePartition(LPFILESYSTEM FileSystem);
 
 /***************************************************************************/
 

--- a/kernel/include/Kernel.h
+++ b/kernel/include/Kernel.h
@@ -29,6 +29,7 @@
 
 #include "Base.h"
 #include "Database.h"
+#include "FileSystem.h"
 #include "Heap.h"
 #include "I386.h"
 #include "ID.h"
@@ -164,6 +165,7 @@ typedef struct tag_KERNELDATA {
     LPLIST PCIDevice;
     LPLIST NetworkDevice;
     LPLIST FileSystem;
+    FILESYSTEM_GLOBAL_INFO FileSystemInfo;
     LPLIST File;
     LPLIST TCPConnection;
     LPLIST Socket;

--- a/kernel/source/EXFS.c
+++ b/kernel/source/EXFS.c
@@ -236,7 +236,11 @@ BOOL MountPartition_EXFS(LPPHYSICALDISK Disk, LPBOOTPARTITION Partition, U32 Bas
     FileSystem->DataStart = FileSystem->PartitionStart + (SECTOR_SIZE * 4);
 
     //-------------------------------------
-    // Register the file system
+    // Update global information and register the file system
+
+    if ((Partition->Disk & 0x80) != 0) {
+        FileSystemSetActivePartition((LPFILESYSTEM)FileSystem);
+    }
 
     ListAddItem(Kernel.FileSystem, FileSystem);
 

--- a/kernel/source/FAT16.c
+++ b/kernel/source/FAT16.c
@@ -202,7 +202,11 @@ BOOL MountPartition_FAT16(LPPHYSICALDISK Disk, LPBOOTPARTITION Partition, U32 Ba
         (FileSystem->Master.NumRootEntries * sizeof(FATDIRENTRY)) / (U32)FileSystem->Master.BytesPerSector;
 
     //-------------------------------------
-    // Register the file system
+    // Update global information and register the file system
+
+    if ((Partition->Disk & 0x80) != 0) {
+        FileSystemSetActivePartition((LPFILESYSTEM)FileSystem);
+    }
 
     ListAddItem(Kernel.FileSystem, FileSystem);
 

--- a/kernel/source/FAT32.c
+++ b/kernel/source/FAT32.c
@@ -219,7 +219,11 @@ BOOL MountPartition_FAT32(LPPHYSICALDISK Disk, LPBOOTPARTITION Partition, U32 Ba
     FileSystem->DataStart = FileSystem->FATStart + (FileSystem->Master.NumFATs * FileSystem->Master.NumSectorsPerFAT);
 
     //-------------------------------------
-    // Register the file system
+    // Update global information and register the file system
+
+    if ((Partition->Disk & 0x80) != 0) {
+        FileSystemSetActivePartition((LPFILESYSTEM)FileSystem);
+    }
 
     ListAddItem(Kernel.FileSystem, FileSystem);
 

--- a/kernel/source/FileSystem.c
+++ b/kernel/source/FileSystem.c
@@ -97,6 +97,23 @@ BOOL GetDefaultFileSystemName(LPSTR Name, LPPHYSICALDISK Disk, U32 PartIndex) {
 /***************************************************************************/
 
 /**
+ * @brief Stores the logical name of the active partition.
+ *
+ * Updates the kernel-wide file system information so that higher level
+ * components can retrieve the currently active partition name.
+ *
+ * @param FileSystem Mounted file system flagged as active in the MBR.
+ */
+void FileSystemSetActivePartition(LPFILESYSTEM FileSystem) {
+    SAFE_USE(FileSystem) {
+        StringCopy(Kernel.FileSystemInfo.ActivePartitionName, FileSystem->Name);
+        DEBUG(TEXT("[FileSystemSetActivePartition] Active partition name set to %s"), FileSystem->Name);
+    }
+}
+
+/***************************************************************************/
+
+/**
  * @brief Mounts extended partitions from a disk.
  *
  * Reads and processes extended partition table entries to discover
@@ -216,6 +233,8 @@ BOOL MountDiskPartitions(LPPHYSICALDISK Disk, LPBOOTPARTITION Partition, U32 Bas
 
 void InitializeFileSystems(void) {
     LPLISTNODE Node;
+
+    Kernel.FileSystemInfo.ActivePartitionName[0] = '\0';
 
     for (Node = Kernel.Disk->First; Node; Node = Node->Next) {
         MountDiskPartitions((LPPHYSICALDISK)Node, NULL, 0);

--- a/kernel/source/KernelData.c
+++ b/kernel/source/KernelData.c
@@ -147,6 +147,7 @@ KERNELDATA SECTION(".data") Kernel = {
     .PCIDevice = &PciDeviceList,
     .NetworkDevice = &NetworkDeviceList,
     .FileSystem = &FileSystemList,
+    .FileSystemInfo = {.ActivePartitionName = ""},
     .File = &FileList,
     .TCPConnection = &TCPConnectionList,
     .Socket = &SocketList,

--- a/kernel/source/Shell.c
+++ b/kernel/source/Shell.c
@@ -1134,6 +1134,16 @@ static void CMD_filesystem(LPSHELLCONTEXT Context) {
     LPLISTNODE Node;
     LPFILESYSTEM FileSystem;
 
+    ConsolePrint(TEXT("General information\n"));
+    if (Kernel.FileSystemInfo.ActivePartitionName[0] != '\0') {
+        ConsolePrint(TEXT("Active partition : %s\n"), Kernel.FileSystemInfo.ActivePartitionName);
+    } else {
+        ConsolePrint(TEXT("Active partition : <none>\n"));
+    }
+
+    ConsolePrint(TEXT("\n"));
+    ConsolePrint(TEXT("Mounted file systems\n"));
+
     for (Node = Kernel.FileSystem->First; Node; Node = Node->Next) {
         FileSystem = (LPFILESYSTEM)Node;
 


### PR DESCRIPTION
## Summary
- add kernel-level file system globals to retain the active partition name
- update partition mount routines to notify the kernel when the active partition is mounted
- show the active partition first in the `filesystem` shell command and document the new state holder

## Testing
- ./scripts/4-5-build-debug.sh *(fails: i686-elf-gcc not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df9507c59483309677211262aecae3