### PR TITLE
Refactor shell command line editing

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -10,6 +10,16 @@ Be aware that it generates A LOT of COM2 output, the scheduler is called every 1
 
 To be completed.
 
+### Command line editing
+
+Interactive editing of shell command lines is implemented in
+`kernel/source/CommandLineEditor.c`. The module processes keyboard input,
+maintains an in-memory history, refreshes the console display, and relies on
+callbacks to retrieve completion suggestions. The shell owns an input state
+structure that embeds the editor instance and provides the shell-specific
+completion callback so the component remains agnostic of higher level shell
+logic.
+
 ### File system globals
 
 The kernel tracks shared file system information in `Kernel.FileSystemInfo`.

--- a/kernel/include/CommandLineEditor.h
+++ b/kernel/include/CommandLineEditor.h
@@ -1,0 +1,78 @@
+/************************************************************************\
+
+    EXOS Kernel
+    Copyright (c) 1999-2025 Jango73
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+    Command Line Editor
+
+\************************************************************************/
+
+#ifndef COMMANDLINEEDITOR_H_INCLUDED
+#define COMMANDLINEEDITOR_H_INCLUDED
+
+#include "Base.h"
+#include "StringArray.h"
+
+/***************************************************************************/
+
+typedef struct tag_COMMANDLINE_COMPLETION_CONTEXT {
+    LPCSTR Buffer;
+    U32 BufferLength;
+    U32 CursorPosition;
+    U32 TokenStart;
+    LPCSTR Token;
+    U32 TokenLength;
+    LPVOID UserData;
+} COMMANDLINE_COMPLETION_CONTEXT, *LPCOMMANDLINE_COMPLETION_CONTEXT;
+
+/***************************************************************************/
+
+typedef BOOL (*COMMANDLINEEDITOR_COMPLETION_CALLBACK)(
+    const COMMANDLINE_COMPLETION_CONTEXT*,
+    LPSTR,
+    U32);
+
+/***************************************************************************/
+
+typedef struct tag_COMMANDLINEEDITOR {
+    STRINGARRAY History;
+    U32 HistoryCapacity;
+    COMMANDLINEEDITOR_COMPLETION_CALLBACK CompletionCallback;
+    LPVOID CompletionUserData;
+} COMMANDLINEEDITOR, *LPCOMMANDLINEEDITOR;
+
+/***************************************************************************/
+
+void CommandLineEditorInit(LPCOMMANDLINEEDITOR Editor, U32 HistoryCapacity);
+void CommandLineEditorDeinit(LPCOMMANDLINEEDITOR Editor);
+void CommandLineEditorSetCompletionCallback(
+    LPCOMMANDLINEEDITOR Editor,
+    COMMANDLINEEDITOR_COMPLETION_CALLBACK Callback,
+    LPVOID UserData);
+BOOL CommandLineEditorReadLine(
+    LPCOMMANDLINEEDITOR Editor,
+    LPSTR Buffer,
+    U32 BufferSize,
+    BOOL MaskCharacters);
+void CommandLineEditorRemember(
+    LPCOMMANDLINEEDITOR Editor,
+    LPCSTR CommandLine);
+void CommandLineEditorClearHistory(LPCOMMANDLINEEDITOR Editor);
+
+/***************************************************************************/
+
+#endif

--- a/kernel/source/CommandLineEditor.c
+++ b/kernel/source/CommandLineEditor.c
@@ -1,0 +1,310 @@
+/************************************************************************\
+
+    EXOS Kernel
+    Copyright (c) 1999-2025 Jango73
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+    Command Line Editor
+
+\************************************************************************/
+
+#include "../include/CommandLineEditor.h"
+
+#include "../include/Console.h"
+#include "../include/Heap.h"
+#include "../include/Keyboard.h"
+#include "../include/Log.h"
+#include "../include/String.h"
+#include "../include/Task.h"
+
+/***************************************************************************/
+
+static void UpdateInputCursor(U32 StartX, U32 StartY, U32 CursorPos) {
+    U32 TargetX = StartX + CursorPos;
+    U32 TargetY = StartY;
+
+    if (Console.Width != 0) {
+        TargetY += TargetX / Console.Width;
+        TargetX %= Console.Width;
+    }
+
+    SetConsoleCursorPosition(TargetX, TargetY);
+}
+
+/***************************************************************************/
+
+static void RefreshInputDisplay(
+    LPCSTR Buffer,
+    U32 StartX,
+    U32 StartY,
+    U32 Length,
+    U32 PreviousLength,
+    U32 CursorPos,
+    BOOL MaskCharacters) {
+    U32 Index;
+
+    SetConsoleCursorPosition(StartX, StartY);
+
+    for (Index = 0; Index < Length; Index++) {
+        if (MaskCharacters) {
+            ConsolePrintChar('*');
+        } else {
+            ConsolePrintChar(Buffer[Index]);
+        }
+    }
+
+    for (Index = Length; Index < PreviousLength; Index++) {
+        ConsolePrintChar(STR_SPACE);
+    }
+
+    UpdateInputCursor(StartX, StartY, CursorPos);
+}
+
+/***************************************************************************/
+
+void CommandLineEditorInit(LPCOMMANDLINEEDITOR Editor, U32 HistoryCapacity) {
+    DEBUG(TEXT("[CommandLineEditorInit] Enter"));
+
+    MemorySet(Editor, 0, sizeof(COMMANDLINEEDITOR));
+
+    Editor->HistoryCapacity = HistoryCapacity;
+    StringArrayInit(&Editor->History, HistoryCapacity);
+    Editor->CompletionCallback = NULL;
+    Editor->CompletionUserData = NULL;
+
+    DEBUG(TEXT("[CommandLineEditorInit] Exit"));
+}
+
+/***************************************************************************/
+
+void CommandLineEditorDeinit(LPCOMMANDLINEEDITOR Editor) {
+    DEBUG(TEXT("[CommandLineEditorDeinit] Enter"));
+
+    StringArrayDeinit(&Editor->History);
+    Editor->HistoryCapacity = 0;
+    Editor->CompletionCallback = NULL;
+    Editor->CompletionUserData = NULL;
+
+    DEBUG(TEXT("[CommandLineEditorDeinit] Exit"));
+}
+
+/***************************************************************************/
+
+void CommandLineEditorSetCompletionCallback(
+    LPCOMMANDLINEEDITOR Editor,
+    COMMANDLINEEDITOR_COMPLETION_CALLBACK Callback,
+    LPVOID UserData) {
+    Editor->CompletionCallback = Callback;
+    Editor->CompletionUserData = UserData;
+}
+
+/***************************************************************************/
+
+BOOL CommandLineEditorReadLine(
+    LPCOMMANDLINEEDITOR Editor,
+    LPSTR Buffer,
+    U32 BufferSize,
+    BOOL MaskCharacters) {
+    KEYCODE KeyCode;
+    U32 CursorPos = 0;
+    U32 Length = 0;
+    U32 DisplayedLength = 0;
+    U32 HistoryPos = Editor->History.Count;
+    U32 StartX = 0;
+    U32 StartY = 0;
+
+    DEBUG(TEXT("[CommandLineEditorReadLine] Enter"));
+
+    if (BufferSize == 0) return FALSE;
+
+    Buffer[0] = STR_NULL;
+    GetConsoleCursorPosition(&StartX, &StartY);
+
+    FOREVER {
+        if (PeekChar()) {
+            GetKeyCode(&KeyCode);
+
+            if (KeyCode.VirtualKey == VK_ESCAPE) {
+                Length = 0;
+                CursorPos = 0;
+                Buffer[0] = STR_NULL;
+                RefreshInputDisplay(
+                    Buffer, StartX, StartY, Length, DisplayedLength, CursorPos, MaskCharacters);
+                DisplayedLength = Length;
+            } else if (KeyCode.VirtualKey == VK_BACKSPACE) {
+                if (CursorPos > 0) {
+                    MemoryMove(Buffer + CursorPos - 1, Buffer + CursorPos, (Length - CursorPos) + 1);
+                    CursorPos--;
+                    Length--;
+                    RefreshInputDisplay(
+                        Buffer, StartX, StartY, Length, DisplayedLength, CursorPos, MaskCharacters);
+                    DisplayedLength = Length;
+                }
+            } else if (KeyCode.VirtualKey == VK_DELETE) {
+                if (CursorPos < Length) {
+                    MemoryMove(Buffer + CursorPos, Buffer + CursorPos + 1, (Length - CursorPos));
+                    Length--;
+                    Buffer[Length] = STR_NULL;
+                    RefreshInputDisplay(
+                        Buffer, StartX, StartY, Length, DisplayedLength, CursorPos, MaskCharacters);
+                    DisplayedLength = Length;
+                }
+            } else if (KeyCode.VirtualKey == VK_LEFT) {
+                if (CursorPos > 0) {
+                    CursorPos--;
+                    UpdateInputCursor(StartX, StartY, CursorPos);
+                }
+            } else if (KeyCode.VirtualKey == VK_RIGHT) {
+                if (CursorPos < Length) {
+                    CursorPos++;
+                    UpdateInputCursor(StartX, StartY, CursorPos);
+                }
+            } else if (KeyCode.VirtualKey == VK_HOME) {
+                CursorPos = 0;
+                UpdateInputCursor(StartX, StartY, CursorPos);
+            } else if (KeyCode.VirtualKey == VK_END) {
+                CursorPos = Length;
+                UpdateInputCursor(StartX, StartY, CursorPos);
+            } else if (KeyCode.VirtualKey == VK_ENTER) {
+                ConsolePrintChar(STR_NEWLINE);
+                Buffer[Length] = STR_NULL;
+                DEBUG(
+                    TEXT("[CommandLineEditorReadLine] ENTER pressed, final buffer: '%s', length=%d"),
+                    Buffer,
+                    Length);
+                break;
+            } else if (KeyCode.VirtualKey == VK_UP) {
+                if (HistoryPos > 0) {
+                    HistoryPos--;
+                    StringCopy(Buffer, StringArrayGet(&Editor->History, HistoryPos));
+                    Length = StringLength(Buffer);
+                    CursorPos = Length;
+                    RefreshInputDisplay(
+                        Buffer, StartX, StartY, Length, DisplayedLength, CursorPos, MaskCharacters);
+                    DisplayedLength = Length;
+                }
+            } else if (KeyCode.VirtualKey == VK_DOWN) {
+                if (HistoryPos < Editor->History.Count) HistoryPos++;
+                if (HistoryPos == Editor->History.Count) {
+                    Buffer[0] = STR_NULL;
+                    Length = 0;
+                    CursorPos = 0;
+                } else {
+                    StringCopy(Buffer, StringArrayGet(&Editor->History, HistoryPos));
+                    Length = StringLength(Buffer);
+                    CursorPos = Length;
+                }
+                RefreshInputDisplay(
+                    Buffer, StartX, StartY, Length, DisplayedLength, CursorPos, MaskCharacters);
+                DisplayedLength = Length;
+            } else if (KeyCode.VirtualKey == VK_TAB) {
+                if (Editor->CompletionCallback) {
+                    STR Replacement[MAX_PATH_NAME];
+                    U32 Start = CursorPos;
+
+                    while (Start && Buffer[Start - 1] != STR_SPACE) {
+                        Start--;
+                    }
+
+                    {
+                        COMMANDLINE_COMPLETION_CONTEXT CompletionContext;
+                        CompletionContext.Buffer = Buffer;
+                        CompletionContext.BufferLength = Length;
+                        CompletionContext.CursorPosition = CursorPos;
+                        CompletionContext.TokenStart = Start;
+                        CompletionContext.Token = Buffer + Start;
+                        CompletionContext.TokenLength = CursorPos - Start;
+                        CompletionContext.UserData = Editor->CompletionUserData;
+
+                        if (Editor->CompletionCallback(
+                                &CompletionContext,
+                                Replacement,
+                                MAX_PATH_NAME)) {
+                            U32 TokenLength = CursorPos - Start;
+                            U32 ReplacementLength = StringLength(Replacement);
+                            U32 TailLength = Length - CursorPos;
+                            U32 NewLength = Length - TokenLength + ReplacementLength;
+
+                            if (NewLength < BufferSize) {
+                                MemoryMove(
+                                    Buffer + Start + ReplacementLength,
+                                    Buffer + CursorPos,
+                                    TailLength + 1);
+                                MemoryCopy(Buffer + Start, Replacement, ReplacementLength);
+                                Length = NewLength;
+                                CursorPos = Start + ReplacementLength;
+                                RefreshInputDisplay(
+                                    Buffer,
+                                    StartX,
+                                    StartY,
+                                    Length,
+                                    DisplayedLength,
+                                    CursorPos,
+                                    MaskCharacters);
+                                DisplayedLength = Length;
+                            }
+                        }
+                    }
+                }
+            } else if (KeyCode.ASCIICode >= STR_SPACE) {
+                if (Length < BufferSize - 1) {
+                    MemoryMove(Buffer + CursorPos + 1, Buffer + CursorPos, (Length - CursorPos) + 1);
+                    Buffer[CursorPos] = KeyCode.ASCIICode;
+                    CursorPos++;
+                    Length++;
+                    Buffer[Length] = STR_NULL;
+                    RefreshInputDisplay(
+                        Buffer, StartX, StartY, Length, DisplayedLength, CursorPos, MaskCharacters);
+                    DisplayedLength = Length;
+                }
+            }
+        }
+
+        Sleep(10);
+    }
+
+    DEBUG(TEXT("[CommandLineEditorReadLine] Exit"));
+
+    return TRUE;
+}
+
+/***************************************************************************/
+
+void CommandLineEditorRemember(
+    LPCOMMANDLINEEDITOR Editor,
+    LPCSTR CommandLine) {
+    if (StringLength(CommandLine) == 0) return;
+    StringArrayMoveToEnd(&Editor->History, CommandLine);
+}
+
+/***************************************************************************/
+
+void CommandLineEditorClearHistory(LPCOMMANDLINEEDITOR Editor) {
+    U32 Index;
+
+    if (Editor->History.Items == NULL) return;
+
+    for (Index = 0; Index < Editor->History.Count; Index++) {
+        if (Editor->History.Items[Index]) {
+            KernelHeapFree(Editor->History.Items[Index]);
+            Editor->History.Items[Index] = NULL;
+        }
+    }
+
+    Editor->History.Count = 0;
+}
+
+/***************************************************************************/


### PR DESCRIPTION
## Summary
- add a reusable `CommandLineEditor` module that centralizes command-line input, history handling, and callback-driven completion logic
- refactor the shell context to embed the editor, funnel input through it, and expose a path-based completion callback
- document the new editing component within the kernel architecture overview

## Testing
- ./scripts/4-5-build-debug.sh *(fails: cross-compiler i686-elf-gcc not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0287da4888330b0ebf71faf74d11e