### PR TITLE
Add ACPI warm reboot routine with legacy fallbacks

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -30,6 +30,16 @@ structure that embeds the editor instance and provides the shell-specific
 completion callback so the component remains agnostic of higher level shell
 logic.
 
+### ACPI services
+
+Advanced power management and reset paths live in `kernel/source/ACPI.c`. The
+module discovers ACPI tables, exposes the parsed configuration, and offers
+helpers for platform control. `ACPIShutdown()` enters the S5 soft-off state and
+falls back to legacy power-off sequences when the ACPI path fails. The new
+`ACPIReboot()` companion performs a warm reboot by first using the ACPI reset
+register (when present) and then chaining to legacy reset controllers to ensure
+the machine restarts even on older chipsets.
+
 ### File system globals
 
 The kernel tracks shared file system information in `Kernel.FileSystemInfo`.

--- a/kernel/include/ACPI.h
+++ b/kernel/include/ACPI.h
@@ -34,6 +34,24 @@
 #pragma pack(push, 1)
 
 /***************************************************************************/
+// ACPI address space identifiers
+
+#define ACPI_ADDRESS_SPACE_SYSTEM_MEMORY 0x00
+#define ACPI_ADDRESS_SPACE_SYSTEM_IO     0x01
+
+/***************************************************************************/
+// Generic Address Structure
+
+typedef struct tag_ACPI_GENERIC_ADDRESS {
+    U8  AddressSpaceId;       // Address space where the register resides
+    U8  RegisterBitWidth;     // Size in bits of the register
+    U8  RegisterBitOffset;    // Bit offset within the register
+    U8  AccessSize;           // Access size (BYTE, WORD, DWORD, QWORD)
+    U32 AddressLow;           // Low 32 bits of the address
+    U32 AddressHigh;          // High 32 bits of the address
+} ACPI_GENERIC_ADDRESS, *LPACPI_GENERIC_ADDRESS;
+
+/***************************************************************************/
 // ACPI Table Header
 
 typedef struct tag_ACPI_TABLE_HEADER {
@@ -242,6 +260,9 @@ typedef struct tag_ACPI_FADT {
     U16 BootArchitectureFlags;     // IA-PC Boot Architecture Flags
     U8  Reserved2;                 // Reserved field
     U32 Flags;                     // Fixed feature flags
+    ACPI_GENERIC_ADDRESS ResetReg; // Reset register descriptor (ACPI 2.0+)
+    U8  ResetValue;                // Value to write to reset register
+    U8  Reserved3[3];              // Reserved field
 } ACPI_FADT, *LPACPI_FADT;
 
 /***************************************************************************/
@@ -279,6 +300,9 @@ U32 MapInterrupt(U8 IRQ);
 
 // Shutdown the system using ACPI
 void ACPIShutdown(void);
+
+// Reboot the system using ACPI
+void ACPIReboot(void);
 
 /***************************************************************************/
 


### PR DESCRIPTION
## Summary
- add an ACPIReboot helper that tries the FADT reset register then falls back to legacy controllers
- extend the FADT definition to expose the ACPI reset register information
- document the ACPI services available in the kernel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e129d79d6c83308f52bf4aef104ed7