### PR TITLE
Handle EXT2 block size and shell path tokens

### DIFF
--- a/boot-hd/Makefile
+++ b/boot-hd/Makefile
@@ -15,6 +15,9 @@ KERNEL_CFG_REF  = ../kernel/configuration/exos.ref.toml
 MTOOLS_CONF     = .mtoolsrc.tmp
 MBR_SOURCE      = source/mbr.asm
 
+# EXT2 layout configuration
+EXT2_BLOCK_SIZE ?= 4096
+
 VBR_SRC         = source/vbr.asm
 PAYLOAD_STUB    = source/vbr-payload-a.asm
 PAYLOAD_C       = source/vbr-payload-c.c
@@ -94,7 +97,7 @@ define CREATE_EXT2_IMAGE
 				echo "ERROR: Partition not found, or PART_OFFSET is zero. Aborting."; \
 				exit 1; \
 			fi; \
-			mke2fs -F -t ext2 -q -L $(EXT2_LABEL) -E offset=$$PART_OFFSET $1; \
+                        mke2fs -F -t ext2 -b $(EXT2_BLOCK_SIZE) -q -L $(EXT2_LABEL) -E offset=$$PART_OFFSET $1; \
 		}; \
 	fi
 endef
@@ -107,7 +110,7 @@ define POPULATE_EXT2_IMAGE
 			exit 1; \
 		fi; \
 		echo "Populating EXT2 filesystem at offset $$PART_OFFSET from $2"; \
-		mke2fs -F -t ext2 -q -L $(EXT2_LABEL) -d $2 -E offset=$$PART_OFFSET $1; \
+                mke2fs -F -t ext2 -b $(EXT2_BLOCK_SIZE) -q -L $(EXT2_LABEL) -d $2 -E offset=$$PART_OFFSET $1; \
 	}
 endef
 

--- a/kernel/include/Script.h
+++ b/kernel/include/Script.h
@@ -81,6 +81,7 @@ typedef struct {
 typedef enum {
     TOKEN_EOF,
     TOKEN_IDENTIFIER,
+    TOKEN_PATH,
     TOKEN_NUMBER,
     TOKEN_STRING,
     TOKEN_OPERATOR,


### PR DESCRIPTION
## Summary
- increase the configurable EXT2 block size and use it during image creation and population
- add TOKEN_PATH lexing so absolute shell paths are parsed and executed as commands
- remove the outdated BootloaderNotes documentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e36fd5ca988330ba08dc8c1cce7932