### PR TITLE
Refactor user account database handling

### DIFF
--- a/kernel/include/Kernel.h
+++ b/kernel/include/Kernel.h
@@ -180,7 +180,6 @@ typedef struct tag_KERNELDATA {
     BOOL DoLogin;                // Enable/disable login sequence (TRUE=enable, FALSE=disable)
     LPLIST UserSessions;         // List of active user sessions
     LPLIST UserAccount;          // List of user accounts
-    DATABASE* UserDatabase;      // User accounts database
     CACHE ObjectTerminationCache;  // Cache for terminated object states with TTL
 } KERNELDATA, *LPKERNELDATA;
 

--- a/kernel/source/KernelData.c
+++ b/kernel/source/KernelData.c
@@ -169,5 +169,4 @@ KERNELDATA SECTION(".data") Kernel = {
     .LanguageCode = "en-US",
     .KeyboardCode = "fr-FR",
     .CPU = {.Name = "", .Type = 0, .Family = 0, .Model = 0, .Stepping = 0, .Features = 0},
-    .MinimumQuantum = 10,
-    .UserDatabase = NULL};
+    .MinimumQuantum = 10};

--- a/kernel/source/UserAccount.c
+++ b/kernel/source/UserAccount.c
@@ -146,6 +146,10 @@ LPUSERACCOUNT CreateUserAccount(LPCSTR UserName, LPCSTR Password, U32 Privilege)
 
     UnlockMutex(MUTEX_ACCOUNTS);
 
+    if (!SaveUserDatabase()) {
+        ERROR(TEXT("[CreateUserAccount] Failed to save user database after creating user %s"), UserName);
+    }
+
     DEBUG(TEXT("[CreateUserAccount] User created successfully"));
     KernelLogText(LOG_VERBOSE, TEXT("Created user account: %s"), UserName);
     return NewUser;


### PR DESCRIPTION
## Summary
- drop the persistent Kernel.UserDatabase pointer in favor of the in-memory user list
- rebuild the database from Kernel.UserAccount when saving and free it after loading to avoid redundant state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e393e9c1dc83308da54b84a6c6c3d9