### PR TITLE
Refactor EXT2 driver to stream file data

### DIFF
--- a/kernel/include/drivers/EXT2.h
+++ b/kernel/include/drivers/EXT2.h
@@ -130,25 +130,6 @@ typedef struct tag_EXT2DIRECTORYENTRY {
 } EXT2DIRECTORYENTRY, *LPEXT2DIRECTORYENTRY;
 
 /***************************************************************************/
-// EXT2 File Record (in-memory representation)
-
-typedef struct tag_EXT2FILEREC {
-    STR Name[MAX_FILE_NAME];
-    U32 Attributes;
-    U32 Size;
-    U32 Capacity;
-    U8* Data;
-} EXT2FILEREC, *LPEXT2FILEREC;
-
-/***************************************************************************/
-// EXT2 File location
-
-typedef struct tag_EXT2FILELOC {
-    LPEXT2FILEREC Record;
-    U32 Offset;
-} EXT2FILELOC, *LPEXT2FILELOC;
-
-/***************************************************************************/
 
 #pragma pack(pop)
 


### PR DESCRIPTION
## Summary
- remove the EXT2 file-record cache and extend filesystem/file structs with streaming state
- add block write helpers and resolve inode blocks on demand without caching
- rework open/read/write paths to stream file data and reject unsupported create/truncate requests

## Testing
- ./scripts/4-5-build-debug.sh *(fails: i686-elf-gcc missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e39ca773008330bf6f1a6494365ea3