### PR TITLE
Add write path to EXT2 driver

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -137,6 +137,17 @@ However, the code uses 32 bit registers when appropriate.
 | **ZFS** | COW, pools, checksums, RAID-Z, snapshots | 7 | 10 | Includes volume mgmt; very large scope. |
 | **NTFS** | MFT, resident/non-resident attrs, bitmap, journal | 7 | 9 | Compression, sparse, ACLs, USN; very rich design. |
 
+### EXT2 driver status
+
+The in-kernel EXT2 driver now handles write operations in addition to the
+existing read path. It allocates inodes and data blocks, updates the superblock
+and group descriptors, and grows regular files using the twelve direct block
+slots provided by the EXT2 layout. Directory creation mirrors the FAT32 helper:
+intermediate path components are created automatically when requested so that
+`mkdir -p` semantics are available across the virtual file system. Newly created
+directories initialize their `.` and `..` entries, bump the parent link count,
+and flush metadata back to disk immediately to keep the on-disk state coherent.
+
 ## EXOS File System - EXFS
 
 ### Notations used in this document


### PR DESCRIPTION
## Summary
- add block and inode allocation helpers to the EXT2 driver and wire them into file creation and writes
- support automatic creation of intermediate directories and update directory metadata when adding entries
- document the new EXT2 write capabilities in the kernel documentation

## Testing
- ./scripts/4-5-build-debug.sh *(fails: missing i686-elf-gcc in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3be68947083308e655280066b75c3