### PR TITLE
Add shared region page population helper and implement ResizeRegion

### DIFF
--- a/kernel/include/Memory.h
+++ b/kernel/include/Memory.h
@@ -71,6 +71,9 @@ PHYSICAL MapLinearToPhysical(LINEAR Address);
 // Allocates physical space for a new region of virtual memory
 LINEAR AllocRegion(LINEAR Base, PHYSICAL Target, U32 Size, U32 Flags);
 
+// Resizes an existing region of virtual memory
+BOOL ResizeRegion(LINEAR Base, PHYSICAL Target, U32 Size, U32 NewSize, U32 Flags);
+
 // Frees physical space of a region of virtual memory
 BOOL FreeRegion(LINEAR Base, U32 Size);
 


### PR DESCRIPTION
## Summary
- extend the AllocRegion doxygen block with flag usage details
- extract shared page population logic for region allocation
- add a ResizeRegion helper to grow or shrink mapped regions using the shared logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ce1093508330bdd68b4523716199