### PR TITLE
Implement heap auto expansion with per-process limits

### DIFF
--- a/documentation/internal/Kernel.md
+++ b/documentation/internal/Kernel.md
@@ -448,6 +448,12 @@ exos-runtime-c.c : malloc() (or any other function)
 
 EXOS implements a lifecycle management system for both processes and tasks that ensures consistent cleanup and prevents resource leaks.
 
+### Process Heap Management
+
+- Every `PROCESS` keeps track of its `MaximumAllocatedMemory`, which is initialized to `N_HalfMemory` for both the kernel and user processes.
+- When a heap allocation exhausts the committed region, the kernel automatically attempts to double the heap size without exceeding the process limit by calling `ResizeRegion`.
+- If the resize operation cannot be completed, the allocator logs an error and the allocation fails gracefully.
+
 ### Status States
 
 **Task Status (Task.Status):**

--- a/kernel/include/Heap.h
+++ b/kernel/include/Heap.h
@@ -44,7 +44,7 @@
 
 typedef struct tag_HEAPBLOCKHEADER {
     U32 TypeID;
-    U32 Size;
+    UINT Size;
     struct tag_HEAPBLOCKHEADER* Next;
     struct tag_HEAPBLOCKHEADER* Prev;
 } HEAPBLOCKHEADER, *LPHEAPBLOCKHEADER;
@@ -67,36 +67,36 @@ void HeapInit(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize);
 
 // Allocates memory space in the calling process' heap
 // Must provide the heap's limits.
-LPVOID HeapAlloc_HBHS(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize, U32 Size);
+LPVOID HeapAlloc_HBHS(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize, UINT Size);
 
 // Reallocates memory space in the calling process' heap
 // Must provide the heap's limits.
-LPVOID HeapRealloc_HBHS(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize, LPVOID Pointer, U32 Size);
+LPVOID HeapRealloc_HBHS(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize, LPVOID Pointer, UINT Size);
 
 // Frees memory space in the calling process' heap
 // Must provide the heap's limits.
 void HeapFree_HBHS(LINEAR HeapBase, UINT HeapSize, LPVOID Pointer);
 
 // Allocates memory space in the specified process' heap
-LPVOID HeapAlloc_P(LPPROCESS Process, U32 Size);
+LPVOID HeapAlloc_P(LPPROCESS Process, UINT Size);
 
 // Reallocates memory space in the specified process' heap
-LPVOID HeapRealloc_P(LPPROCESS Process, LPVOID Pointer, U32 Size);
+LPVOID HeapRealloc_P(LPPROCESS Process, LPVOID Pointer, UINT Size);
 
 // Frees memory space in the specified process' heap
 void HeapFree_P(LPPROCESS Process, LPVOID Pointer);
 
 // Allocates memory space in the kernel's heap
-LPVOID KernelHeapAlloc(U32 Size);
+LPVOID KernelHeapAlloc(UINT Size);
 
 // Reallocates memory space in the kernel's heap
-LPVOID KernelHeapRealloc(LPVOID Pointer, U32 Size);
+LPVOID KernelHeapRealloc(LPVOID Pointer, UINT Size);
 
 // Frees memory space in the kernel's heap
 void KernelHeapFree(LPVOID Pointer);
 
 // Allocates memory space in the calling process' heap
-LPVOID HeapAlloc(U32 Size);
+LPVOID HeapAlloc(UINT Size);
 
 // Reallocates memory space in the calling process' heap
 LPVOID HeapRealloc(LPVOID Pointer, U32 Size);

--- a/kernel/include/Heap.h
+++ b/kernel/include/Heap.h
@@ -54,7 +54,8 @@ typedef struct tag_HEAPBLOCKHEADER {
 typedef struct tag_HEAPCONTROLBLOCK {
     U32 TypeID;
     LINEAR HeapBase;
-    U32 HeapSize;
+    UINT HeapSize;
+    LPPROCESS Owner;
     LPHEAPBLOCKHEADER FreeLists[HEAP_NUM_SIZE_CLASSES];
     LPHEAPBLOCKHEADER LargeFreeList;
     LPVOID FirstUnallocated;
@@ -62,19 +63,19 @@ typedef struct tag_HEAPCONTROLBLOCK {
 
 /***************************************************************************/
 
-void HeapInit(LINEAR HeapBase, U32 HeapSize);
+void HeapInit(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize);
 
 // Allocates memory space in the calling process' heap
 // Must provide the heap's limits.
-LPVOID HeapAlloc_HBHS(LINEAR HeapBase, U32 HeapSize, U32 Size);
+LPVOID HeapAlloc_HBHS(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize, U32 Size);
 
 // Reallocates memory space in the calling process' heap
 // Must provide the heap's limits.
-LPVOID HeapRealloc_HBHS(LINEAR HeapBase, U32 HeapSize, LPVOID Pointer, U32 Size);
+LPVOID HeapRealloc_HBHS(LPPROCESS Process, LINEAR HeapBase, UINT HeapSize, LPVOID Pointer, U32 Size);
 
 // Frees memory space in the calling process' heap
 // Must provide the heap's limits.
-void HeapFree_HBHS(LINEAR HeapBase, U32 HeapSize, LPVOID Pointer);
+void HeapFree_HBHS(LINEAR HeapBase, UINT HeapSize, LPVOID Pointer);
 
 // Allocates memory space in the specified process' heap
 LPVOID HeapAlloc_P(LPPROCESS Process, U32 Size);

--- a/kernel/include/Process.h
+++ b/kernel/include/Process.h
@@ -72,7 +72,8 @@ struct tag_PROCESS {
     U32 Flags;               // Process creation flags
     PHYSICAL PageDirectory;  // This process' page directory
     LINEAR HeapBase;
-    U32 HeapSize;
+    UINT HeapSize;
+    UINT MaximumAllocatedMemory;
     U32 ExitCode;            // This process' exit code
     STR FileName[MAX_PATH_NAME];
     STR CommandLine[MAX_PATH_NAME];

--- a/kernel/source/Process.c
+++ b/kernel/source/Process.c
@@ -51,6 +51,7 @@ PROCESS SECTION(".data") KernelProcess = {
     .PageDirectory = 0,             // Page directory
     .HeapBase = 0,                  // Heap base
     .HeapSize = 0,                  // Heap size
+    .MaximumAllocatedMemory = N_HalfMemory, // Maximum heap allocation limit
     .FileName = "",                 // File name
     .CommandLine = "",              // Command line
     .WorkFolder = ROOT,             // Working directory
@@ -73,6 +74,7 @@ void InitializeKernelProcess(void) {
     DEBUG(TEXT("[InitializeKernelProcess] Enter"));
 
     KernelProcess.PageDirectory = GetPageDirectory();
+    KernelProcess.MaximumAllocatedMemory = N_HalfMemory;
     KernelProcess.HeapSize = N_1MB;
 
     DEBUG(TEXT("[InitializeKernelProcess] Memory : %x"), KernelStartup.MemorySize);
@@ -88,7 +90,7 @@ void InitializeKernelProcess(void) {
     }
 
     KernelProcess.HeapBase = (LINEAR)HeapBase;
-    HeapInit(KernelProcess.HeapBase, KernelProcess.HeapSize);
+    HeapInit(&KernelProcess, KernelProcess.HeapBase, KernelProcess.HeapSize);
 
     StringCopy(KernelProcess.FileName, KernelStartup.CommandLine);
     StringCopy(KernelProcess.CommandLine, KernelStartup.CommandLine);
@@ -152,6 +154,7 @@ LPPROCESS NewProcess(void) {
     This->Privilege = PRIVILEGE_USER;
     This->Status = PROCESS_STATUS_ALIVE;
     This->Flags = 0; // Will be set by CreateProcess
+    This->MaximumAllocatedMemory = N_HalfMemory;
     This->TaskCount = 0;
     This->Session = NULL;
 
@@ -383,7 +386,7 @@ BOOL CreateProcess(LPPROCESSINFO Info) {
     U32 FileSize = 0;
     U32 CodeSize = 0;
     U32 DataSize = 0;
-    U32 HeapSize = 0;
+    UINT HeapSize = 0;
     U32 StackSize = 0;
     U32 TotalSize = 0;
     BOOL Result = FALSE;
@@ -620,7 +623,7 @@ BOOL CreateProcess(LPPROCESSINFO Info) {
     Process->HeapBase = HeapBase;
     Process->HeapSize = HeapSize;
 
-    HeapInit(Process->HeapBase, Process->HeapSize);
+    HeapInit(Process, Process->HeapBase, Process->HeapSize);
 
     // HeapDump(KernelProcess.HeapBase, KernelProcess.HeapSize);
     // HeapDump(Process->HeapBase, Process->HeapSize);


### PR DESCRIPTION
## Summary
- add a MaximumAllocatedMemory field to PROCESS and initialize it to N_HalfMemory for kernel and user processes
- track heap owners in the heap control block and automatically attempt to double heap size via ResizeRegion without exceeding the process limit
- update the kernel documentation to explain the new heap growth behaviour and limits

## Testing
- not run (reason: no automated test coverage available)


------
https://chatgpt.com/codex/tasks/task_e_68e4e47f4b108330b9808c244e9c5c01