### PR TITLE
Refactor disk caches to use scored TTL entries

### DIFF
--- a/kernel/include/Disk.h
+++ b/kernel/include/Disk.h
@@ -113,6 +113,7 @@ typedef struct tag_DISKACCESS {
 #define MAX_DISK 4
 #define TIMEOUT 10000
 #define NUM_BUFFERS 32
+#define DISK_CACHE_TTL_MS (5 * 60 * 1000)
 
 /***************************************************************************/
 // Disk sector buffer
@@ -120,7 +121,6 @@ typedef struct tag_DISKACCESS {
 typedef struct tag_SECTORBUFFER {
     U32 SectorLow;
     U32 SectorHigh;
-    U32 Score;
     U32 Dirty;
     U8 Data[SECTOR_SIZE];
 } SECTORBUFFER, *LPSECTORBUFFER;
@@ -137,8 +137,6 @@ typedef struct tag_BLOCKPARAMS {
 // Function prototypes
 
 void SectorToBlockParams(LPDISKGEOMETRY Geometry, U32 Sector, LPBLOCKPARAMS Block);
-U32 FindSectorInBuffers(LPSECTORBUFFER Buffer, U32 NumBuffers, U32 SectorLow, U32 SectorHigh);
-U32 GetEmptyBuffer(LPSECTORBUFFER Buffer, U32 NumBuffers);
 
 /***************************************************************************/
 

--- a/kernel/include/utils/Cache.h
+++ b/kernel/include/utils/Cache.h
@@ -40,6 +40,8 @@
 typedef struct {
     LPVOID Data;
     U32 ExpirationTime;
+    U32 TTL;
+    U32 Score;
     BOOL Valid;
 } CACHE_ENTRY, *LPCACHE_ENTRY;
 
@@ -57,6 +59,7 @@ void CacheDeinit(LPCACHE Cache);
 BOOL CacheAdd(LPCACHE Cache, LPVOID Data, U32 TTL_MS);
 LPVOID CacheFind(LPCACHE Cache, BOOL (*Matcher)(LPVOID Data, LPVOID Context), LPVOID Context);
 void CacheCleanup(LPCACHE Cache, U32 CurrentTime);
+LPCACHE_ENTRY CacheFindLowestScoreEntry(LPCACHE Cache);
 
 /************************************************************************/
 

--- a/kernel/source/Disk.c
+++ b/kernel/source/Disk.c
@@ -1,4 +1,3 @@
-
 /************************************************************************\
 
     EXOS Kernel
@@ -47,53 +46,3 @@ void SectorToBlockParams(LPDISKGEOMETRY Geometry, U32 Sector, LPBLOCKPARAMS Bloc
 }
 
 /***************************************************************************/
-
-U32 FindSectorInBuffers(LPSECTORBUFFER Buffer, U32 NumBuffers, U32 SectorLow, U32 SectorHigh) {
-    UNUSED(SectorHigh);
-
-    U32 Index = 0;
-    U32 BufNum = MAX_U32;
-
-    for (Index = 0; Index < NumBuffers; Index++) {
-        if (Buffer[Index].SectorLow == SectorLow) {
-            Buffer[Index].Score++;
-            BufNum = Index;
-        } else {
-            if (Buffer[Index].SectorLow != MAX_U32) {
-                if (Buffer[Index].Score) Buffer[Index].Score--;
-            }
-        }
-    }
-
-    return BufNum;
-}
-
-/***************************************************************************/
-
-U32 GetEmptyBuffer(LPSECTORBUFFER Buffer, U32 NumBuffers) {
-    U32 Index;
-    U32 WorstScore = MAX_U32;
-    U32 WorstIndex = MAX_U32;
-
-    for (Index = 0; Index < NumBuffers; Index++) {
-        if (Buffer[Index].SectorLow == MAX_U32) {
-            return Index;
-        } else if (Buffer[Index].SectorLow != MAX_U32) {
-            if (Buffer[Index].Score < WorstScore) {
-                WorstScore = Buffer[Index].Score;
-                WorstIndex = Index;
-            }
-        }
-    }
-
-    //-------------------------------------
-    // Invalidate the buffer and reset its score
-
-    if (WorstIndex != MAX_U32) {
-        Buffer[WorstIndex].Score = 10;
-        Buffer[WorstIndex].SectorLow = MAX_U32;
-        Buffer[WorstIndex].SectorHigh = MAX_U32;
-    }
-
-    return WorstIndex;
-}


### PR DESCRIPTION
## Summary
- extend the generic cache with TTL tracking, score decay, and a helper to locate the lowest-score entry
- refactor the ATA and SATA drivers to rely on the shared cache with 5-minute TTL sector buffers
- drop the legacy buffer search helpers from the disk utilities now that cache-based management replaces them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53027c9908330967ced81bd1ed769