### PR TITLE
Finish driver interrupt integration and add polling switch

### DIFF
--- a/documentation/todo/DeviceInterruptPlan.md
+++ b/documentation/todo/DeviceInterruptPlan.md
@@ -69,3 +69,5 @@
 - **Step 4 complete**: the E1000 driver installs a top-half that acknowledges causes, relies on `SAFE_USE_VALID_ID`, and signals deferred work.
 - **Step 5 complete**: `DeferredWorkDispatcher` replaces the busy polling loop, driving bottom halves from interrupts or the polling fallback, and keeps network maintenance shared.
 - **Step 6 complete**: the dispatcher lives in `kernel/source/DeferredWork.c`, headers expose the API, and the legacy `NetworkManagerTask` has been removed.
+- **Step 7 complete**: drivers such as `E1000` program interrupt masks, acknowledge causes inside the ISR, and rely on deferred work plus watchdog polling instead of bespoke loops.
+- **Step 8 complete**: runtime configuration `General.Polling` toggles between interrupt and polling modes, and the dispatcher exposes a poll registration API for devices.

--- a/kernel/configuration/exos.ref.toml
+++ b/kernel/configuration/exos.ref.toml
@@ -21,6 +21,8 @@
 # Configure deferred work timings
 DeferredWorkWaitTimeoutMS=50
 DeferredWorkPollDelayMS=5
+# 0 = interrupt driven (default), 1 = polling driven
+Polling=0
 # Enable or disable login sequence (1=enable, 0=disable)
 DoLogin=1
 

--- a/kernel/include/DeferredWork.h
+++ b/kernel/include/DeferredWork.h
@@ -32,6 +32,7 @@ typedef struct tag_DEFERRED_WORK_REGISTRATION {
 BOOL InitializeDeferredWork(void);
 void ShutdownDeferredWork(void);
 U32 DeferredWorkRegister(const DEFERRED_WORK_REGISTRATION *Registration);
+U32 DeferredWorkRegisterPollOnly(DEFERRED_WORK_POLL_CALLBACK PollCallback, LPVOID Context, LPCSTR Name);
 void DeferredWorkUnregister(U32 Handle);
 void DeferredWorkSignal(U32 Handle);
 BOOL DeferredWorkIsPollingMode(void);

--- a/kernel/include/utils/Helpers.h
+++ b/kernel/include/utils/Helpers.h
@@ -37,6 +37,7 @@
 // Configuration paths
 
 #define CONFIG_GENERAL_QUANTUM_MS                       "General.QuantumMS"
+#define CONFIG_GENERAL_POLLING                          "General.Polling"
 #define CONFIG_GENERAL_DEFERRED_WORK_WAIT_TIMEOUT_MS    "General.DeferredWorkWaitTimeoutMS"
 #define CONFIG_GENERAL_DEFERRED_WORK_POLL_DELAY_MS      "General.DeferredWorkPollDelayMS"
 #define CONFIG_NETWORK_LOCAL_IP                         "Network.LocalIP"


### PR DESCRIPTION
## Summary
- allow deferred work items to register polling-only callbacks and expose a helper for them
- add a runtime General.Polling configuration flag with logging when the dispatcher switches modes
- update the E1000 driver to acknowledge causes through a helper and respect the global polling mode
- document completion of stages 7 and 8 in the device interrupt plan and extend the sample configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e007c2b948330adc44a10796779af)